### PR TITLE
feat: implement save search preferences

### DIFF
--- a/gui/script.js
+++ b/gui/script.js
@@ -270,7 +270,9 @@ function start_bot() {
 
   // Save the query counts to global settings before running.
   if (!dailyOnly) {
-    pywebview.api.set_queries_counts(pc, mobile).catch(err => {
+    pywebview.api.set_queries_counts(pc, mobile).then(ok => {
+      if (!ok) console.error('Failed to save query counts (backend returned false).');
+    }).catch(err => {
       console.error('Failed to save query counts:', err);
     });
   }
@@ -302,7 +304,9 @@ document.addEventListener('DOMContentLoaded', function () {
       const pc = parseInt(pcField.value, 10);
       const mobile = parseInt(mobileField.value, 10);
       if (!isNaN(pc) && !isNaN(mobile) && pc >= 0 && pc <= 130 && mobile >= 0 && mobile <= 99) {
-        pywebview.api.set_queries_counts(pc, mobile).catch(err => {
+        pywebview.api.set_queries_counts(pc, mobile).then(ok => {
+          if (!ok) console.error('Failed to auto-save query counts (backend returned false).');
+        }).catch(err => {
           console.error('Failed to auto-save query counts:', err);
         });
       }

--- a/gui/script.js
+++ b/gui/script.js
@@ -268,6 +268,13 @@ function start_bot() {
   const stopBtn = document.getElementById('stop_btn');
   if (stopBtn) stopBtn.disabled = false;
 
+  // Save the query counts to global settings before running.
+  if (!dailyOnly) {
+    pywebview.api.set_queries_counts(pc, mobile).catch(err => {
+      console.error('Failed to save query counts:', err);
+    });
+  }
+
   update_status_indicator('executing');
   pywebview.api.main(pc, mobile, dailyOnly);
 }
@@ -286,6 +293,23 @@ document.addEventListener('DOMContentLoaded', function () {
   const toggle = document.getElementById('dailyOnlyToggle');
   if (toggle) toggle.addEventListener('change', _sync_daily_only_ui);
   _sync_daily_only_ui();
+
+  // Auto-save query counts when they change (on blur).
+  const pcField = document.getElementById('count_pc');
+  const mobileField = document.getElementById('count_mobile');
+  const save_counts = () => {
+    if (pcField && mobileField) {
+      const pc = parseInt(pcField.value, 10);
+      const mobile = parseInt(mobileField.value, 10);
+      if (!isNaN(pc) && !isNaN(mobile) && pc >= 0 && pc <= 130 && mobile >= 0 && mobile <= 99) {
+        pywebview.api.set_queries_counts(pc, mobile).catch(err => {
+          console.error('Failed to auto-save query counts:', err);
+        });
+      }
+    }
+  };
+  if (pcField) pcField.addEventListener('blur', save_counts);
+  if (mobileField) mobileField.addEventListener('blur', save_counts);
 });
 
 function enable_start_button() {
@@ -1115,6 +1139,16 @@ window.addEventListener('pywebviewready', function() {
   pywebview.api.get_settings().then(function(settings) {
     const toggle = document.getElementById('hideBrowserToggle');
     if (toggle) toggle.checked = Boolean(settings.hide_browser);
+  });
+
+  // Load saved query counts from global settings.
+  pywebview.api.get_queries_counts().then(function(counts) {
+    const pcField = document.getElementById('count_pc');
+    const mobileField = document.getElementById('count_mobile');
+    if (pcField) pcField.value = counts.queries_pc;
+    if (mobileField) mobileField.value = counts.queries_mobile;
+  }).catch(err => {
+    console.error('Failed to load query counts:', err);
   });
 
   refresh_account_ui();

--- a/src/accounts/settings.py
+++ b/src/accounts/settings.py
@@ -97,6 +97,9 @@ class GlobalSettingsManager:
             # introduced in v3.3; users who prefer the standard X = quit
             # can flip it off in Settings. Read once at app startup.
             "close_to_tray": True,
+            # Default query counts.
+            "queries_pc": 30,
+            "queries_mobile": 20,
         }
 
         if APP_DIR and not os.path.exists(APP_DIR):
@@ -154,4 +157,24 @@ class GlobalSettingsManager:
         """Persist the current account id in settings."""
         settings = self.get_settings()
         settings["current_account_id"] = account_id
+        self.save_settings(settings)
+
+    def get_queries_pc(self):
+        """Return the saved PC queries count from settings."""
+        return self.get_settings().get("queries_pc", 30)
+
+    def set_queries_pc(self, count):
+        """Persist the PC queries count in settings."""
+        settings = self.get_settings()
+        settings["queries_pc"] = max(0, min(130, int(count)))
+        self.save_settings(settings)
+
+    def get_queries_mobile(self):
+        """Return the saved mobile queries count from settings."""
+        return self.get_settings().get("queries_mobile", 20)
+
+    def set_queries_mobile(self, count):
+        """Persist the mobile queries count in settings."""
+        settings = self.get_settings()
+        settings["queries_mobile"] = max(0, min(99, int(count)))
         self.save_settings(settings)

--- a/src/api.py
+++ b/src/api.py
@@ -329,9 +329,21 @@ class AutoRewarderAPI:
             bool: True if successfully saved, False otherwise.
         """
         try:
+            before = (
+                self.global_settings.get_queries_pc(),
+                self.global_settings.get_queries_mobile(),
+            )
+
             self.global_settings.set_queries_pc(queries_pc)
             self.global_settings.set_queries_mobile(queries_mobile)
-            self.log(f"Search counts saved: PC={queries_pc}, Mobile={queries_mobile}")
+
+            after = (
+                self.global_settings.get_queries_pc(),
+                self.global_settings.get_queries_mobile(),
+            )
+
+            if after != before:
+                self.log(f"Search counts saved: PC={after[0]}, Mobile={after[1]}")
             return True
         except Exception as e:
             self.log(f"[WARNING] Failed to save search counts: {e}")

--- a/src/api.py
+++ b/src/api.py
@@ -305,6 +305,38 @@ class AutoRewarderAPI:
         state = "ON (X → tray)" if value else "OFF (X → quit)"
         self.log(f"Close-to-tray: {state}. Restart to apply.")
 
+    def get_queries_counts(self):
+        """
+        Return the saved PC and Mobile query counts from global settings.
+
+        Returns:
+            dict: {"queries_pc": int, "queries_mobile": int}
+        """
+        return {
+            "queries_pc": self.global_settings.get_queries_pc(),
+            "queries_mobile": self.global_settings.get_queries_mobile(),
+        }
+
+    def set_queries_counts(self, queries_pc, queries_mobile):
+        """
+        Save PC and Mobile query counts to global settings.
+
+        Args:
+            queries_pc (int): Number of PC searches.
+            queries_mobile (int): Number of mobile searches.
+
+        Returns:
+            bool: True if successfully saved, False otherwise.
+        """
+        try:
+            self.global_settings.set_queries_pc(queries_pc)
+            self.global_settings.set_queries_mobile(queries_mobile)
+            self.log(f"Search counts saved: PC={queries_pc}, Mobile={queries_mobile}")
+            return True
+        except Exception as e:
+            self.log(f"[WARNING] Failed to save search counts: {e}")
+            return False
+
     # ------------------------------------------------------------------
     # Exposed to JS: per-account schedule + startup
     # ------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces persistent storage and auto-saving for the PC and mobile query counts in the application's global settings. The changes ensure that user input for query counts is saved automatically and restored on app startup, improving user experience and data consistency.

**Settings persistence and API integration:**

* Added new settings fields (`queries_pc` and `queries_mobile`) with default values to the global settings in `settings.py`, and implemented getter and setter methods to manage these values with validation. 
* Added `get_queries_counts` and `set_queries_counts` API methods in `api.py` to expose reading and writing of query counts to the GUI layer.

**GUI improvements and auto-save:**

* On application startup, the GUI now loads and displays the saved query counts.
* The query count fields (`count_pc` and `count_mobile`) now auto-save their values to settings when the user leaves the input field (on blur), and query counts are also saved before starting the main process (unless in daily-only mode).