### PR TITLE
Close new tabs and handle missing news tab

### DIFF
--- a/src/search/engine.py
+++ b/src/search/engine.py
@@ -172,23 +172,35 @@ class SearchEngine:
 
                 tabs_config = [
                     {"name": "All", "priority": 70, "id": None},
-                    {"name": "Images", "priority": 10, "id": "b-scopeListItem-images"},
-                    {"name": "Videos", "priority": 10, "id": "b-scopeListItem-video"},
-                    {"name": "News", "priority": 10, "id": "b-scopeListItem-news"},
+                    {"name": "Images", "priority": 7.5, "id": "b-scopeListItem-images"},
+                    {"name": "Videos", "priority": 7.5, "id": "b-scopeListItem-video"},
+                    {"name": "News", "priority": 15, "id": "b-scopeListItem-news"},
                 ]
 
                 weights = [tab["priority"] for tab in tabs_config]
                 chosen_tab = random.choices(tabs_config, weights=weights, k=1)[0]
 
                 if chosen_tab["name"] != "All":
+                    # Check if news tab exists, if it doesn't choose Images or Videos
+                    if chosen_tab["name"] == "News":
+                        try:
+                            xpath = f"//nav/ul/li[@id='{chosen_tab['id']}']/a"
+                            tab_element = driver.find_element(By.XPATH, xpath)
+                        except NoSuchElementException:
+                            chosen_tab=random.choice(tabs_config[1:3])
+                    
                     self._log(f"Chosen behavior: Switch to {chosen_tab['name']}")
                     try:
+                        # Get the current tab
+                        main_tab=driver.current_window_handle
+                        
                         # Find the tab element using its id
-                        xpath = f"//li[@id='{chosen_tab['id']}']//a"
+                        xpath = f"//nav/ul/li[@id='{chosen_tab['id']}']/a"
                         tab_element = driver.find_element(By.XPATH, xpath)
-
+                        
                         # Move mouse and click the tab
                         human.click_element(tab_element)
+                        
                         time.sleep(random.uniform(3, 6))
 
                     except NoSuchElementException:
@@ -221,6 +233,19 @@ class SearchEngine:
                 # Pause after scrolling
                 time.sleep(random.uniform(2, 4))
 
+                # Close all tabs other than main
+                if chosen_tab["name"] != "All":
+                    new_tabs=[tab for tab in driver.window_handles if tab != main_tab]
+                    for tab in new_tabs:
+                        try:
+                            driver.switch_to.window(tab)
+                            driver.close()
+                        except Exception:
+                            pass
+                    
+                    if main_tab in driver.window_handles:
+                        driver.switch_to.window(main_tab)
+                
                 # Add to history.json
                 self._add_to_history(query, "Success")
 
@@ -242,3 +267,4 @@ class SearchEngine:
                     return
                 self._log(f"[ERROR] Unknown error on attempt #{i+1}: {e}")
                 self._add_to_history(query, f"[ERROR] Unknown Error: {str(e)[:50]}")
+


### PR DESCRIPTION
Added logic to close new tabs when opened, and logic to handle missing news tab. I also changed weights of chosen behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result tab handling so searches are more likely to land on the expected category.
  * Made browser cleanup more reliable by closing extra tabs and returning to the main search view after scrolling.
  * Reduced the chance of search flow interruptions caused by tab-switching issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->