### PR TITLE
Support Microsoft's new Next.js Rewards dashboard (per-account, balance, daily set, /earn activities & quests)

### DIFF
--- a/gui/dashboard.css
+++ b/gui/dashboard.css
@@ -186,7 +186,7 @@ body {
 /* ---- Lifetime metric grid ---- */
 .metric-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 12px;
 }
 

--- a/gui/dashboard.html
+++ b/gui/dashboard.html
@@ -72,6 +72,14 @@
           <span class="metric-label">Daily cards</span>
         </div>
         <div class="metric">
+          <span class="metric-value" id="m_earn">0</span>
+          <span class="metric-label">Earn cards</span>
+        </div>
+        <div class="metric">
+          <span class="metric-value" id="m_quests">0</span>
+          <span class="metric-label">Quest tasks</span>
+        </div>
+        <div class="metric">
           <span class="metric-value" id="m_runs">0</span>
           <span class="metric-label">Runs</span>
         </div>
@@ -86,6 +94,8 @@
           <span class="legend-item"><span class="legend-dot legend-pc"></span>PC</span>
           <span class="legend-item"><span class="legend-dot legend-mobile"></span>Mobile</span>
           <span class="legend-item"><span class="legend-dot legend-daily"></span>Daily</span>
+          <span class="legend-item"><span class="legend-dot legend-earn"></span>Earn</span>
+          <span class="legend-item"><span class="legend-dot legend-quests"></span>Quests</span>
         </div>
       </div>
       <div id="runs_chart" class="runs-chart"></div>
@@ -191,12 +201,16 @@
       if (ls.pc_searches) parts.push(ls.pc_searches + ' PC');
       if (ls.mobile_searches) parts.push(ls.mobile_searches + ' mobile');
       if (ls.daily_cards) parts.push(ls.daily_cards + ' cards');
+      if (ls.earn_cards) parts.push(ls.earn_cards + ' earn');
+      if (ls.quest_tasks) parts.push(ls.quest_tasks + ' quests');
       sessSub.textContent = parts.length ? parts.join(' · ') : 'No activity recorded yet';
 
       // Lifetime metrics.
       document.getElementById('m_pc').textContent = fmt(life.pc_searches || 0);
       document.getElementById('m_mobile').textContent = fmt(life.mobile_searches || 0);
       document.getElementById('m_cards').textContent = fmt(life.daily_cards || 0);
+      document.getElementById('m_earn').textContent = fmt(life.earn_cards || 0);
+      document.getElementById('m_quests').textContent = fmt(life.quest_tasks || 0);
       document.getElementById('m_runs').textContent = fmt(life.runs || 0);
 
       render_runs_chart(stats.daily || {}, stats.constants);
@@ -242,7 +256,9 @@
       const pps = (consts && consts.points_per_search) || 3;
       const ppc = (consts && consts.points_per_card) || 10;
 
-      // dailyData is { "YYYY-MM-DD": {pc, mobile, cards, runs} } from backend.
+      // dailyData is { "YYYY-MM-DD": {pc, mobile, cards, earn, quests, runs} }
+      // from the backend. Daily cards, /earn cards and quest tasks each get
+      // their own stacked segment (older records simply lack earn/quests → 0).
       const byDay = new Map();
       for (const key of Object.keys(dailyData || {})) {
         if (key.length !== 10) continue;
@@ -251,6 +267,8 @@
           pc: (v.pc || 0) * pps,
           mobile: (v.mobile || 0) * pps,
           daily: (v.cards || 0) * ppc,
+          earn: (v.earn || 0) * ppc,
+          quests: (v.quests || 0) * ppc,
         });
       }
 
@@ -266,13 +284,15 @@
 
       const totals = days.map(d => {
         const e = byDay.get(d);
-        return e.pc + e.mobile + e.daily;
+        return e.pc + e.mobile + e.daily + e.earn + e.quests;
       });
       const max = Math.max(1, ...totals);
       const MAX_PX = 128;  // pixel height of the tallest day's bar
 
       // bottom → top order (column-reverse appends first child at the bottom).
       const SEGMENTS = [
+        { key: 'quests', cls: 'bar-quests', label: 'Quests' },
+        { key: 'earn', cls: 'bar-earn', label: 'Earn' },
         { key: 'daily', cls: 'bar-daily', label: 'Daily' },
         { key: 'mobile', cls: 'bar-mobile', label: 'Mobile' },
         { key: 'pc', cls: 'bar-pc', label: 'PC' },
@@ -280,7 +300,7 @@
 
       days.forEach(d => {
         const e = byDay.get(d);
-        const total = e.pc + e.mobile + e.daily;
+        const total = e.pc + e.mobile + e.daily + e.earn + e.quests;
 
         const col = document.createElement('div');
         col.className = 'bar-col';
@@ -293,6 +313,7 @@
         stack.className = 'bar-stack';
         stack.title = `${day_label(d)}\nPC: ${fmt(e.pc)} pts` +
           `\nMobile: ${fmt(e.mobile)} pts\nDaily: ${fmt(e.daily)} pts` +
+          `\nEarn: ${fmt(e.earn)} pts\nQuests: ${fmt(e.quests)} pts` +
           `\nTotal: ${fmt(total)} pts`;
 
         for (const seg of SEGMENTS) {

--- a/gui/script.js
+++ b/gui/script.js
@@ -814,6 +814,17 @@ function build_schedule_card(item) {
   const body = document.createElement('div');
   body.className = 'schedule-card-body';
 
+  // Dashboard variant row (applies to any run, not just scheduled ones):
+  // which Microsoft Rewards dashboard this account uses for the Daily Set.
+  const DASHBOARD_VARIANTS = ['auto', 'legacy', 'new'];
+  const dashDefault = DASHBOARD_VARIANTS.includes(item.dashboard_variant)
+    ? item.dashboard_variant : 'auto';
+  body.appendChild(make_select_field('Rewards dashboard', 'schedule-dashboard', dashDefault, [
+    { value: 'auto', label: 'Auto (detect)' },
+    { value: 'legacy', label: 'Legacy' },
+    { value: 'new', label: 'New' },
+  ]));
+
   // Advanced scheduling sub-toggle row.
   const advRow = document.createElement('label');
   advRow.className = 'sched-adv-row';
@@ -915,6 +926,28 @@ function build_schedule_card(item) {
   return card;
 }
 
+function make_select_field(labelText, className, value, options) {
+  const wrap = document.createElement('div');
+  wrap.className = 'form-field';
+
+  const label = document.createElement('label');
+  label.textContent = labelText;
+  wrap.appendChild(label);
+
+  const select = document.createElement('select');
+  select.className = className;
+  options.forEach(opt => {
+    const o = document.createElement('option');
+    o.value = opt.value;
+    o.textContent = opt.label;
+    if (opt.value === value) o.selected = true;
+    select.appendChild(o);
+  });
+  wrap.appendChild(select);
+
+  return wrap;
+}
+
 function make_form_field(labelText, inputType, className, value, opts) {
   const wrap = document.createElement('div');
   wrap.className = 'form-field';
@@ -952,6 +985,9 @@ async function save_settings() {
     const runDuration = parseInt(card.querySelector('.schedule-run-duration').value, 10);
     const queriesPerHour = parseInt(card.querySelector('.schedule-queries-per-hour').value, 10);
     const runTime = card.querySelector('.schedule-run-time').value;
+    const dashEl = card.querySelector('.schedule-dashboard');
+    const dashboardVariant = dashEl && ['auto', 'legacy', 'new'].includes(dashEl.value)
+      ? dashEl.value : 'auto';
 
     if (enabled) {
       if (isNaN(pc) || pc < 0 || pc > 130) {
@@ -984,6 +1020,7 @@ async function save_settings() {
 
     payloads.push({
       id: id,
+      dashboardVariant: dashboardVariant,
       payload: {
         enabled: enabled,
         advancedScheduling: advancedScheduling,
@@ -997,6 +1034,12 @@ async function save_settings() {
   }
 
   try {
+    // Persist each account's dashboard choice first (independent of the
+    // schedule payload; kept out of the results[] slicing below).
+    await Promise.all(payloads.map(p =>
+      pywebview.api.set_dashboard_variant(p.id, p.dashboardVariant)
+    ));
+
     const scheduleCalls = payloads.map(p =>
       pywebview.api.set_schedule(p.id, p.payload)
     );

--- a/gui/styles.css
+++ b/gui/styles.css
@@ -731,10 +731,12 @@ input[type="number"]:focus {
   display: inline-block;
 }
 
-/* Shared segment / legend colours (PC, Mobile, Daily). */
+/* Shared segment / legend colours (PC, Mobile, Daily, Earn, Quests). */
 .legend-pc,     .bar-pc     { background-color: var(--accent); }
 .legend-mobile, .bar-mobile { background-color: #a78bfa; }
 .legend-daily,  .bar-daily  { background-color: var(--success); }
+.legend-earn,   .bar-earn   { background-color: #f59e0b; }
+.legend-quests, .bar-quests { background-color: #f472b6; }
 
 /* =========================================================================
    Activity feed

--- a/src/accounts/meta.py
+++ b/src/accounts/meta.py
@@ -22,6 +22,15 @@ DEFAULT_ACCOUNT_SCHEDULE = {
     "run_time": "09:00",
 }
 
+# Which Microsoft Rewards dashboard this account uses. Microsoft is rolling out
+# a new React/Next.js dashboard that has a completely different DOM from the
+# legacy `mee-rewards-*` one; the Daily Set automation must branch on it.
+#   "auto"   -> detect at runtime which dashboard rendered (default)
+#   "legacy" -> force the historical mee-rewards-* dashboard
+#   "new"    -> force the new Next.js dashboard
+DASHBOARD_VARIANTS = ("auto", "legacy", "new")
+DEFAULT_DASHBOARD_VARIANT = "auto"
+
 
 def default_account_schedule():
     """Return a fresh copy of the default per-account schedule."""
@@ -168,3 +177,33 @@ class AccountMetaManager:
         meta = self.get_meta()
         meta["schedule"] = sched
         self.save_meta(meta)
+
+    def get_dashboard_variant(self):
+        """
+        Return this account's Rewards dashboard variant.
+
+        Returns one of DASHBOARD_VARIANTS, defaulting to DEFAULT_DASHBOARD_VARIANT
+        when unset or invalid (backward compatible: pre-existing meta.json files
+        simply resolve to "auto").
+        """
+        variant = self.get_meta().get("dashboard_variant")
+        if variant in DASHBOARD_VARIANTS:
+            return variant
+        return DEFAULT_DASHBOARD_VARIANT
+
+    def set_dashboard_variant(self, variant):
+        """
+        Persist this account's Rewards dashboard variant.
+
+        Args:
+            variant: one of DASHBOARD_VARIANTS ("auto", "legacy", "new").
+
+        Returns:
+            bool: True if persisted, False if the value was rejected.
+        """
+        if variant not in DASHBOARD_VARIANTS:
+            return False
+        meta = self.get_meta()
+        meta["dashboard_variant"] = variant
+        self.save_meta(meta)
+        return True

--- a/src/api.py
+++ b/src/api.py
@@ -153,7 +153,11 @@ class AutoRewarderAPI:
             profile = edge_profile_path(current_id)
             self.account_meta = AccountMetaManager(current_id)
             self.history = HistoryManager(history_path(current_id), logger=self.log)
-            self.daily_set = DailySet(status_path(current_id), logger=self.log)
+            self.daily_set = DailySet(
+                status_path(current_id),
+                logger=self.log,
+                dashboard_variant=self.account_meta.get_dashboard_variant(),
+            )
             self.stats = StatsManager(stats_path(current_id), logger=self.log)
             self.driver_manager = DriverManager(
                 profile_path=profile, hide_browser=self.hide_browser
@@ -520,18 +524,48 @@ class AutoRewarderAPI:
         return AccountMetaManager(account_id).get_schedule()
 
     def get_all_schedules(self):
-        """Return [{id, label, first_setup_done, schedule}] for the settings modal."""
+        """Return [{id, label, first_setup_done, schedule, dashboard_variant}] for the settings modal."""
         result = []
         for acc in self.account_manager.list():
+            meta = AccountMetaManager(acc["id"])
             result.append(
                 {
                     "id": acc["id"],
                     "label": acc["label"],
                     "first_setup_done": acc["first_setup_done"],
-                    "schedule": AccountMetaManager(acc["id"]).get_schedule(),
+                    "schedule": meta.get_schedule(),
+                    "dashboard_variant": meta.get_dashboard_variant(),
                 }
             )
         return result
+
+    def get_dashboard_variant(self, account_id):
+        """Return a specific account's Rewards dashboard variant, or None if unknown."""
+        if not account_id or not self.account_manager.exists(account_id):
+            return None
+        return AccountMetaManager(account_id).get_dashboard_variant()
+
+    def set_dashboard_variant(self, account_id, variant):
+        """
+        Persist a specific account's Rewards dashboard variant.
+
+        Args:
+            account_id (str): The account to update.
+            variant (str): One of "auto", "legacy", "new".
+
+        Returns:
+            bool: True if persisted, False if the account or value is invalid.
+        """
+        if not account_id or not self.account_manager.exists(account_id):
+            return False
+        ok = AccountMetaManager(account_id).set_dashboard_variant(variant)
+        if not ok:
+            return False
+        # Keep the live DailySet in sync if we changed the current account, so a
+        # run started right after the toggle uses the new variant.
+        if account_id == self.account_manager.current_id() and self.daily_set:
+            self.daily_set.dashboard_variant = variant
+        return True
 
     def set_schedule(self, account_id, payload):
         """

--- a/src/api.py
+++ b/src/api.py
@@ -119,7 +119,13 @@ class AutoRewarderAPI:
         self.stats = None
 
         # Per-run stats accumulators, reset at the start of every main() call.
-        self._session_counts = {"pc": 0, "mobile": 0, "cards": 0}
+        self._session_counts = {
+            "pc": 0,
+            "mobile": 0,
+            "cards": 0,
+            "earn": 0,
+            "quests": 0,
+        }
         self._last_scraped_balance = None
         # Last balance-scrape diagnostic ({value, via, candidates, url, title}),
         # surfaced to the dashboard so a failed read can be debugged in place.
@@ -1748,6 +1754,8 @@ class AutoRewarderAPI:
                     "pc_searches": stats["lifetime"]["pc_searches"],
                     "mobile_searches": stats["lifetime"]["mobile_searches"],
                     "daily_cards": stats["lifetime"]["daily_cards"],
+                    "earn_cards": stats["lifetime"].get("earn_cards", 0),
+                    "quest_tasks": stats["lifetime"].get("quest_tasks", 0),
                 }
             )
         return result
@@ -2161,7 +2169,13 @@ class AutoRewarderAPI:
 
         # Reset per-run stats accumulators. _run_phase / _run_daily_only feed
         # these; _record_session_stats() folds them into stats.json at the end.
-        self._session_counts = {"pc": 0, "mobile": 0, "cards": 0}
+        self._session_counts = {
+            "pc": 0,
+            "mobile": 0,
+            "cards": 0,
+            "earn": 0,
+            "quests": 0,
+        }
         self._last_scraped_balance = None
 
         try:
@@ -2250,6 +2264,8 @@ class AutoRewarderAPI:
                 pc_searches=self._session_counts.get("pc", 0),
                 mobile_searches=self._session_counts.get("mobile", 0),
                 daily_cards=self._session_counts.get("cards", 0),
+                earn_cards=self._session_counts.get("earn", 0),
+                quest_tasks=self._session_counts.get("quests", 0),
                 balance=self._last_scraped_balance,
             )
         except Exception as e:
@@ -2312,7 +2328,10 @@ class AutoRewarderAPI:
             )
             # Record cards completed + scrape the balance while we're still on
             # the rewards dashboard, before any Stop check returns early.
-            self._session_counts["cards"] += self.daily_set.last_totals.get("newly", 0)
+            totals = self.daily_set.last_totals
+            self._session_counts["cards"] += totals.get("newly", 0)
+            self._session_counts["earn"] += totals.get("earn", 0)
+            self._session_counts["quests"] += totals.get("quests", 0)
             self._try_scrape_balance()
             if self._stop_event.is_set():
                 self.log("Daily tasks aborted by Stop.")
@@ -2383,9 +2402,10 @@ class AutoRewarderAPI:
                 ran_daily_set = True
                 # Record cards + scrape the balance while still on the rewards
                 # dashboard, before the Stop check can short-circuit.
-                self._session_counts["cards"] += self.daily_set.last_totals.get(
-                    "newly", 0
-                )
+                totals = self.daily_set.last_totals
+                self._session_counts["cards"] += totals.get("newly", 0)
+                self._session_counts["earn"] += totals.get("earn", 0)
+                self._session_counts["quests"] += totals.get("quests", 0)
                 self._try_scrape_balance()
                 if not self._stop_event.is_set():
                     if success:

--- a/src/api.py
+++ b/src/api.py
@@ -1775,31 +1775,46 @@ class AutoRewarderAPI:
         except Exception:
             pass
 
-        try:
-            driver.get("https://rewards.bing.com")
-        except TimeoutException:
-            pass  # scrape whatever managed to render
-        except Exception as e:
-            self._last_balance_debug = {"error": str(e)[:120]}
-            return None
-
-        # Give the SPA a beat to mount before the first read.
-        time.sleep(2.5)
+        # Try the dashboard root first (legacy dashboard + the new dashboard when
+        # migrated accounts are redirected there), then the explicit /dashboard
+        # path used by the new Next.js app in case the root doesn't render it.
+        urls = ["https://rewards.bing.com", "https://rewards.bing.com/dashboard"]
 
         attempts = max(1, attempts)
         self._last_balance_debug = {}
-        for _ in range(attempts):
-            info = scrape_points_balance_debug(driver)
-            self._last_balance_debug = info
-            value = info.get("value")
-            if isinstance(value, int) and value >= 0:
-                # No log here — the caller emits a single user-facing line, so
-                # a scrape+update pair doesn't read as a duplicate.
-                return value
-            time.sleep(1.5)
 
-        # Not found. Details are kept in _last_balance_debug for the dashboard's
-        # on-demand refresh diagnostic; nothing is logged to the activity feed.
+        for url in urls:
+            try:
+                driver.get(url)
+            except TimeoutException:
+                pass  # scrape whatever managed to render
+            except Exception as e:
+                self._last_balance_debug = {"error": str(e)[:120], "url": url}
+                continue
+
+            # Give the SPA a beat to mount before the first read.
+            time.sleep(2.5)
+
+            for _ in range(attempts):
+                info = scrape_points_balance_debug(driver)
+                self._last_balance_debug = info
+                value = info.get("value")
+                if isinstance(value, int) and value >= 0:
+                    # No log here — the caller emits a single user-facing line, so
+                    # a scrape+update pair doesn't read as a duplicate.
+                    return value
+                time.sleep(1.5)
+
+        # Not found on any URL. Surface the diagnostic to the activity feed so a
+        # failure can be debugged from the logs (which page did we land on, what
+        # did the selectors match), then also keep it in _last_balance_debug for
+        # the dashboard's on-demand refresh diagnostic.
+        info = self._last_balance_debug or {}
+        self.log(
+            "[WARNING] Balance not found — "
+            f"url={info.get('url')!r} title={info.get('title')!r} "
+            f"via={info.get('via')!r} candidates={info.get('candidates') or []}"
+        )
         return None
 
     def _refresh_balance_on_launch(self, driver):

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -312,8 +312,16 @@ class NewDashboardDailySet:
             except Exception:
                 continue
 
-    def _locate_anchor(self, driver, destination, index, section_id="dailyset"):
-        """Find the card <a> for `destination` in a section, else the index-th."""
+    def _locate_anchor(self, driver, destination, section_id="dailyset"):
+        """
+        Find the card <a> matching `destination` in a section by its exact href.
+
+        Returns None when there's no exact match: the activity list is filtered
+        (completed cards, quests and badge-less promos are dropped), so a
+        positional fallback would index the raw anchors out of step with that
+        list and could click the wrong card. Callers fall back to direct
+        navigation instead.
+        """
         try:
             anchors = driver.find_elements(By.CSS_SELECTOR, f"#{section_id} a[href]")
         except Exception:
@@ -324,8 +332,6 @@ class NewDashboardDailySet:
                     return a
             except Exception:
                 continue
-        if 0 <= index < len(anchors):
-            return anchors[index]
         return None
 
     def _locate_quest_task(self, driver, destination):
@@ -354,13 +360,26 @@ class NewDashboardDailySet:
                 continue
         return None
 
-    def _click_anchor(self, driver, human, anchor, main_tab, stop_event):
+    def _click_anchor(
+        self,
+        driver,
+        human,
+        anchor,
+        main_tab,
+        stop_event,
+        return_url=DASHBOARD_URL,
+        section_id="dailyset",
+    ):
         """
-        Click a daily-set card the way a user does (a real pointer click that
-        opens the card's new tab from the dashboard) — this is what credits the
-        offer; a bare navigation to the destination URL does not. Handles the new
-        tab (dwell + close) or a same-tab navigation, then returns to the
-        dashboard. Returns True if the click was dispatched and handled.
+        Click a card the way a user does (a real pointer click that opens the
+        card's new tab) — this is what credits the offer; a bare navigation to
+        the destination URL does not. Handles the new tab (dwell + close) or a
+        same-tab navigation.
+
+        On a same-tab navigation, returns to `return_url` and expands
+        `section_id` so the caller's remaining anchors stay discoverable (each
+        flow — daily set, earn page — has its own page and section). Returns True
+        if the click was dispatched and handled.
         """
         try:
             # Skip a card that's momentarily 0x0 (SPA re-render / still collapsed).
@@ -408,16 +427,17 @@ class NewDashboardDailySet:
                 return True
 
             if driver.current_url != cur_url:
-                # Opened in the same tab: dwell, then return to the dashboard.
+                # Opened in the same tab: dwell, then return to the caller's
+                # page/section so its remaining anchors stay discoverable.
                 time.sleep(random.uniform(3, 6))
                 try:
                     human.scroll_page()
                 except Exception:
                     pass
-                driver.get(DASHBOARD_URL)
+                driver.get(return_url)
                 self._wait_ready(driver)
                 time.sleep(random.uniform(1.5, 2.5))
-                self._expand_section(driver)
+                self._expand_section(driver, section_id)
                 return True
 
             # Nothing happened — click missed.
@@ -564,7 +584,7 @@ class NewDashboardDailySet:
         self._log(f"'earn-page': {len(items)} activity(ies) to do.")
         main_tab = driver.current_window_handle
         done = 0
-        for idx, item in enumerate(items):
+        for item in items:
             if stop_event is not None and stop_event.is_set():
                 self._log("Stop requested — halting 'earn-page'.")
                 break
@@ -573,9 +593,15 @@ class NewDashboardDailySet:
             if not isinstance(dest, str) or not dest.startswith("http"):
                 continue
             self._log(f"Opening activity: {title} (+{item.get('points')})")
-            anchor = self._locate_anchor(driver, dest, idx, section_id="moreactivities")
+            anchor = self._locate_anchor(driver, dest, section_id="moreactivities")
             if anchor is not None and self._click_anchor(
-                driver, human, anchor, main_tab, stop_event
+                driver,
+                human,
+                anchor,
+                main_tab,
+                stop_event,
+                return_url=EARN_URL,
+                section_id="moreactivities",
             ):
                 done += 1
                 continue
@@ -600,7 +626,9 @@ class NewDashboardDailySet:
                 self._log(f"[WARNING] Failed to open '{title}': {e}")
 
         if done:
-            self.last_totals["newly"] = self.last_totals.get("newly", 0) + done
+            # These opens aren't re-read/confirmed, so they count as attempts
+            # only; `newly` stays reserved for verified completions (the
+            # daily-set pass sets it from a completion re-read).
             self.last_totals["attempted"] = self.last_totals.get("attempted", 0) + done
         self._log(f"'earn-page': opened {done} activity(ies) this run.")
 
@@ -694,11 +722,11 @@ class NewDashboardDailySet:
                 self._log(f"Opening quest task: {ttitle}")
                 anchor = self._locate_quest_task(driver, dest)
                 if anchor is not None and self._click_anchor(
-                    driver, human, anchor, main_tab, stop_event
+                    driver, human, anchor, main_tab, stop_event, return_url=url
                 ):
                     opened += 1
-                    # The click returns to the dashboard or quest tab; re-open the
-                    # quest page so the next task's element can be relocated fresh.
+                    # Re-open the quest page so the next task's element can be
+                    # relocated fresh (the DOM re-renders after each click).
                     try:
                         driver.get(url)
                         self._wait_ready(driver)
@@ -707,7 +735,8 @@ class NewDashboardDailySet:
                         pass
 
         if opened:
-            self.last_totals["newly"] = self.last_totals.get("newly", 0) + opened
+            # Unverified opens count as attempts only; `newly` is reserved for
+            # verified completions.
             self.last_totals["attempted"] = (
                 self.last_totals.get("attempted", 0) + opened
             )
@@ -794,7 +823,7 @@ class NewDashboardDailySet:
             self._expand_section(driver)
 
             attempted = 0
-            for idx, item in enumerate(todays):
+            for item in todays:
                 if stop_event is not None and stop_event.is_set():
                     self._log("Stop requested — halting new-dashboard daily set.")
                     break
@@ -810,7 +839,7 @@ class NewDashboardDailySet:
                     continue
 
                 self._log(f"Opening daily-set activity: {title}")
-                anchor = self._locate_anchor(driver, destination, idx)
+                anchor = self._locate_anchor(driver, destination)
                 if anchor is not None and self._click_anchor(
                     driver, human, anchor, main_tab, stop_event
                 ):
@@ -856,14 +885,30 @@ class NewDashboardDailySet:
                 driver.get(DASHBOARD_URL)
                 self._wait_ready(driver)
                 time.sleep(random.uniform(1.5, 2.5))
-                after_items = self._read_items(driver) or self._read_items_dom(driver)
-                after = self._todays_items(after_items)
-                if after:
+                # The re-read can race a still-streaming (partial) snapshot; one
+                # missing cards would make them look completed and inflate
+                # `newly`. Only trust a snapshot that covers at least as many
+                # cards as we started with — retry (JSON then DOM) until it does.
+                after = []
+                for _ in range(5):
+                    after = self._todays_items(
+                        self._read_items(driver) or self._read_items_dom(driver)
+                    )
+                    if len(after) >= len(todays):
+                        break
+                    time.sleep(1.5)
+                if after and len(after) >= len(todays):
                     verified = True
                     still_incomplete = sum(
                         1 for it in after if not it.get("isCompleted")
                     )
                     newly = max(0, len(incomplete) - still_incomplete)
+                else:
+                    self._log(
+                        "[INFO] Post-run snapshot incomplete "
+                        f"({len(after)}/{len(todays)} cards) — not confirming "
+                        "completion this run."
+                    )
             except Exception:
                 pass
 

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -84,14 +84,20 @@ try {
   for (var i = 0; i < links.length; i++) {
     var a = links[i];
     var href = a.href || a.getAttribute('href') || '';
-    if (href.indexOf('bing.com') < 0 && href.indexOf('/search') < 0) continue;
-    var txt = (a.textContent || '').replace(/\s+/g, ' ').trim();
-    var low = txt.toLowerCase();
+    // Only real daily-set activities point at a Bing search. This also excludes
+    // the section header's "Gagner plus" / "Earn more" link (→ /earn), whose
+    // absolute href still contains "bing.com".
+    if (href.indexOf('bing.com/search') < 0) continue;
+    // Title only: the card's bold title node, not the whole card text (which
+    // also holds the description, points and status).
+    var tEl = a.querySelector('.text-globalBody2Strong') || a.querySelector('p');
+    var title = tEl ? (tEl.textContent || '').replace(/\s+/g, ' ').trim() : '';
+    var low = (a.textContent || '').toLowerCase();
     var done = false;
     for (var d = 0; d < doneWords.length; d++) {
       if (low.indexOf(doneWords[d]) >= 0) { done = true; break; }
     }
-    out.push({ destination: href, title: txt.slice(0, 60), isCompleted: done, date: null });
+    out.push({ destination: href, title: title.slice(0, 80), isCompleted: done, date: null });
   }
   return out;
 } catch (e) { return []; }
@@ -272,11 +278,23 @@ class NewDashboardDailySet:
             # Brief settle so late RSC chunks finish streaming in.
             time.sleep(random.uniform(2, 3))
 
-            # Primary: poll the embedded RSC JSON (streams in progressively).
+            # Primary: poll the embedded RSC JSON (streams in progressively). It
+            # is authoritative — it carries the exact destination + isCompleted.
             items = self._read_items_polling(driver)
             source = "json"
             # Fallback: read today's cards from the rendered #dailyset section.
             if not items:
+                # Always log why the JSON path came up empty, even when the DOM
+                # fallback succeeds, so we can tell "chunk not streamed yet" from
+                # "extraction bug" without another round-trip.
+                diag = self._diagnostics(driver)
+                self._log(
+                    "[INFO] New-dashboard JSON had no daily-set items — "
+                    f"chunks={diag.get('chunks')} blobLen={diag.get('blobLen')} "
+                    f"hasDailySetItems={diag.get('hasKey')} "
+                    f"hasDailysetSection={diag.get('hasDailyset')} "
+                    f"url={diag.get('url')!r}"
+                )
                 items = self._read_items_dom(driver)
                 source = "dom"
 

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -110,6 +110,9 @@ try {
     var a = links[i];
     var href = a.href || a.getAttribute('href') || '';
     if (href.indexOf('bing.com') < 0) continue;
+    // Quests are multi-task punchcards handled separately (see _run_quests);
+    // their entry card links to /earn/quest/<id>, not a Bing search.
+    if (href.indexOf('/earn/quest/') >= 0) continue;
     // Skip completed cards via their green "success" badge (language-independent).
     if (a.querySelector('[class*="statusSuccess"]')) continue;
     var txt = (a.textContent || '').replace(/\s+/g, ' ').trim();
@@ -118,6 +121,61 @@ try {
     var tEl = a.querySelector('.text-globalBody2Strong') || a.querySelector('p');
     var title = tEl ? (tEl.textContent || '').replace(/\s+/g, ' ').trim() : '';
     out.push({ destination: href, title: title.slice(0, 80), points: parseInt(m[1], 10) });
+  }
+  return out;
+} catch (e) { return []; }
+"""
+
+# Discover /earn "quest" punchcards. Each is an <a> linking to its own
+# /earn/quest/<id> page (not a Bing search), with a "+N" points badge and an
+# "N/M" progress counter. Both markers are numeric / design-token based, so this
+# stays language-independent. The progress lets the caller skip finished quests.
+_QUESTS_JS = r"""
+try {
+  var out = [];
+  var seen = {};
+  var links = document.querySelectorAll('a[href*="/earn/quest/"]');
+  for (var i = 0; i < links.length; i++) {
+    var a = links[i];
+    var href = a.href || a.getAttribute('href') || '';
+    if (!href) continue;
+    var key = href.split('?')[0].split('#')[0];
+    if (seen[key]) continue;
+    seen[key] = 1;
+    var txt = (a.textContent || '').replace(/\s+/g, ' ').trim();
+    var pts = 0; var pm = txt.match(/\+\s*(\d+)/); if (pm) pts = parseInt(pm[1], 10);
+    var done = null, total = null;
+    var prog = txt.match(/(\d+)\s*\/\s*(\d+)/);
+    if (prog) { done = parseInt(prog[1], 10); total = parseInt(prog[2], 10); }
+    var tEl = a.querySelector('.text-globalBody2Strong') || a.querySelector('p');
+    var title = tEl ? (tEl.textContent || '').replace(/\s+/g, ' ').trim() : '';
+    out.push({ url: key, title: title.slice(0, 80), points: pts, done: done, total: total });
+  }
+  return out;
+} catch (e) { return []; }
+"""
+
+# Read the actionable tasks on a quest page. Tasks live in the design-token
+# "rewardsTableAltBg" list; each is a Bing-search link that must be really
+# clicked to credit. A task is actionable only if its link is NOT disabled:
+# punchcard tasks unlock one per ~24h and carry aria-disabled / data-disabled
+# until then, and completed tasks have no link at all.
+_QUEST_TASKS_JS = r"""
+try {
+  var out = [];
+  var scope = document.querySelector('[class*="rewardsTableAltBg"]') || document;
+  var links = scope.querySelectorAll('[href*="bing.com/search"]');
+  for (var i = 0; i < links.length; i++) {
+    var el = links[i];
+    if ((el.getAttribute('aria-disabled') || '') === 'true') continue;
+    if ((el.getAttribute('data-disabled') || '') === 'true') continue;
+    if (el.hasAttribute('disabled')) continue;
+    var href = el.getAttribute('href') || '';
+    if (!href) continue;
+    var row = el.closest('div');
+    var tEl = row ? row.querySelector('h3, .text-globalBody2Strong') : null;
+    var title = tEl ? (tEl.textContent || '').replace(/\s+/g, ' ').trim() : '';
+    out.push({ destination: href, title: title.slice(0, 80) });
   }
   return out;
 } catch (e) { return []; }
@@ -268,6 +326,32 @@ class NewDashboardDailySet:
                 continue
         if 0 <= index < len(anchors):
             return anchors[index]
+        return None
+
+    def _locate_quest_task(self, driver, destination):
+        """
+        Find the actionable task link for `destination` on a quest page. Unlike
+        daily-set cards, a quest task's clickable is a <span role="link"> (not an
+        <a>), so this queries by href within the task list and skips disabled
+        (locked) links.
+        """
+        try:
+            links = driver.find_elements(
+                By.CSS_SELECTOR,
+                '[class*="rewardsTableAltBg"] [href*="bing.com/search"]',
+            )
+        except Exception:
+            return None
+        for el in links:
+            try:
+                if (el.get_attribute("aria-disabled") or "").lower() == "true":
+                    continue
+                if (el.get_attribute("data-disabled") or "").lower() == "true":
+                    continue
+                if el.get_attribute("href") == destination:
+                    return el
+            except Exception:
+                continue
         return None
 
     def _click_anchor(self, driver, human, anchor, main_tab, stop_event):
@@ -430,9 +514,9 @@ class NewDashboardDailySet:
 
     def perform(self, driver, human, stop_event=None):
         """
-        Run the new-dashboard point-earning tasks: the Daily Set (/dashboard) and
-        then the "earn-page" activities (/earn). Returns the Daily Set
-        outcome (used to mark today done); the earn pass is best-effort.
+        Run the new-dashboard point-earning tasks: the Daily Set (/dashboard),
+        the "earn-page" activities and the quests (/earn). Returns the Daily Set
+        outcome (used to mark today done); the earn/quest passes are best-effort.
         """
         daily_ok = self._run_daily_set(driver, human, stop_event=stop_event)
         if stop_event is not None and stop_event.is_set():
@@ -442,6 +526,13 @@ class NewDashboardDailySet:
         except Exception as e:
             if not (stop_event is not None and stop_event.is_set()):
                 self._log(f"[WARNING] 'earn-page' pass failed: {e}")
+        if stop_event is not None and stop_event.is_set():
+            return daily_ok
+        try:
+            self._run_quests(driver, human, stop_event=stop_event)
+        except Exception as e:
+            if not (stop_event is not None and stop_event.is_set()):
+                self._log(f"[WARNING] Quest pass failed: {e}")
         return daily_ok
 
     def _run_more_activities(self, driver, human, stop_event=None):
@@ -512,6 +603,115 @@ class NewDashboardDailySet:
             self.last_totals["newly"] = self.last_totals.get("newly", 0) + done
             self.last_totals["attempted"] = self.last_totals.get("attempted", 0) + done
         self._log(f"'earn-page': opened {done} activity(ies) this run.")
+
+    def _run_quests(self, driver, human, stop_event=None):
+        """
+        Complete the currently-actionable tasks inside /earn "quest" punchcards.
+
+        A quest is a multi-task card that links to its own /earn/quest/<id> page;
+        each task is a Bing-search link that must be really clicked to credit
+        (like a daily-set card). Punchcard tasks are time-gated — typically only
+        one unlocks per ~24h — so a run completes only what's unlocked right now;
+        locked tasks carry aria-disabled / data-disabled and are skipped. Full
+        completion of a quest therefore takes several daily runs.
+        """
+        self._log("Checking 'earn-page' quests (new dashboard)")
+        try:
+            driver.get(EARN_URL)
+            self._wait_ready(driver)
+            time.sleep(random.uniform(1.5, 2.5))
+        except Exception as e:
+            self._log(f"[WARNING] Could not open the earn page for quests: {e}")
+            return
+
+        # Expand collapsible sections so lazily-rendered quest cards materialize.
+        self._expand_section(driver, "moreactivities")
+        time.sleep(random.uniform(0.5, 1.0))
+
+        try:
+            quests = driver.execute_script(_QUESTS_JS)
+        except Exception as e:
+            self._log(f"[WARNING] Could not read quests: {e}")
+            return
+        if not isinstance(quests, list) or not quests:
+            self._log("Quests: none found.")
+            return
+
+        # Skip quests already fully complete (progress N/N).
+        pending = []
+        for q in quests:
+            if not isinstance(q, dict):
+                continue
+            url = q.get("url")
+            if not isinstance(url, str) or "/earn/quest/" not in url:
+                continue
+            d, t = q.get("done"), q.get("total")
+            if isinstance(d, int) and isinstance(t, int) and t > 0 and d >= t:
+                continue
+            pending.append(q)
+
+        if not pending:
+            self._log("Quests: all complete.")
+            return
+
+        self._log(f"Quests: {len(pending)} incomplete quest(s) to check.")
+        main_tab = driver.current_window_handle
+        opened = 0
+        for q in pending:
+            if stop_event is not None and stop_event.is_set():
+                self._log("Stop requested — halting quests.")
+                break
+            url = q["url"]
+            title = q.get("title") or "quest"
+            try:
+                driver.get(url)
+                self._wait_ready(driver)
+                time.sleep(random.uniform(1.5, 2.5))
+            except Exception as e:
+                self._log(f"[WARNING] Could not open quest '{title}': {e}")
+                continue
+
+            try:
+                tasks = driver.execute_script(_QUEST_TASKS_JS)
+            except Exception as e:
+                self._log(f"[WARNING] Could not read tasks for quest '{title}': {e}")
+                continue
+            if not isinstance(tasks, list) or not tasks:
+                self._log(
+                    f"Quest '{title}': no actionable task right now "
+                    "(locked or complete)."
+                )
+                continue
+
+            self._log(f"Quest '{title}': {len(tasks)} actionable task(s).")
+            for task in tasks:
+                if stop_event is not None and stop_event.is_set():
+                    break
+                dest = task.get("destination")
+                ttitle = task.get("title") or "task"
+                if not isinstance(dest, str) or not dest.startswith("http"):
+                    continue
+                self._log(f"Opening quest task: {ttitle}")
+                anchor = self._locate_quest_task(driver, dest)
+                if anchor is not None and self._click_anchor(
+                    driver, human, anchor, main_tab, stop_event
+                ):
+                    opened += 1
+                    # The click returns to the dashboard or quest tab; re-open the
+                    # quest page so the next task's element can be relocated fresh.
+                    try:
+                        driver.get(url)
+                        self._wait_ready(driver)
+                        time.sleep(random.uniform(1, 2))
+                    except Exception:
+                        pass
+
+        if opened:
+            self.last_totals["newly"] = self.last_totals.get("newly", 0) + opened
+            self.last_totals["attempted"] = (
+                self.last_totals.get("attempted", 0) + opened
+            )
+        self._log(f"Quests: opened {opened} task(s) this run.")
 
     def _run_daily_set(self, driver, human, stop_event=None):
         """

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -22,6 +22,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 
 DASHBOARD_URL = "https://rewards.bing.com/dashboard"
+EARN_URL = "https://rewards.bing.com/earn"
 
 # Concatenate every streamed RSC chunk (`window.__next_f` is a list of
 # `[1, "<chunk>"]` entries) and pull out each `dailySetItems` array, returning
@@ -69,36 +70,54 @@ try {
 
 # DOM fallback: read today's daily-set activities straight from the rendered
 # `#dailyset` section when the RSC JSON isn't available. The section holds only
-# today's cards, each an <a> pointing at the Bing search that credits it. We
-# best-effort detect completion from a small set of localized "done" words; when
-# unsure we treat the card as incomplete (re-opening a completed daily search is
-# harmless).
+# today's cards, each an <a> pointing at the Bing search that credits it.
+# Completion is read from the green "success" badge (a design-system class),
+# which is language-independent.
 _DOM_DAILY_SET_JS = r"""
 try {
   var out = [];
   var root = document.getElementById('dailyset');
   if (!root) return out;
-  var doneWords = ['terminé','termine','completed','complete','done','erledigt',
-    'abgeschlossen','completado','completada','completato','concluído','voltooid',
-    'terminado','fait'];
   var links = root.querySelectorAll('a[href]');
   for (var i = 0; i < links.length; i++) {
     var a = links[i];
     var href = a.href || a.getAttribute('href') || '';
-    // Only real daily-set activities point at a Bing search. This also excludes
-    // the section header's "Gagner plus" / "Earn more" link (→ /earn), whose
-    // absolute href still contains "bing.com".
+    // Only real daily-set activities point at a Bing search (this also excludes
+    // the section header's "earn more" link, whose absolute href has bing.com).
     if (href.indexOf('bing.com/search') < 0) continue;
-    // Title only: the card's bold title node, not the whole card text (which
-    // also holds the description, points and status).
+    // Title only: the card's bold title node, not the whole card text.
     var tEl = a.querySelector('.text-globalBody2Strong') || a.querySelector('p');
     var title = tEl ? (tEl.textContent || '').replace(/\s+/g, ' ').trim() : '';
-    var low = (a.textContent || '').toLowerCase();
-    var done = false;
-    for (var d = 0; d < doneWords.length; d++) {
-      if (low.indexOf(doneWords[d]) >= 0) { done = true; break; }
-    }
+    // Completed cards carry a green "success" badge (language-independent).
+    var done = !!a.querySelector('[class*="statusSuccess"]');
     out.push({ destination: href, title: title.slice(0, 80), isCompleted: done, date: null });
+  }
+  return out;
+} catch (e) { return []; }
+"""
+
+# The /earn "more activities" (#moreactivities) section: point-earning search
+# cards. An earnable, not-yet-done card shows a "+N" points badge; completed ones
+# show a green "success" badge instead, and promos (referral, redeem, extension)
+# have no "+N" badge — the "+N" gate keeps only the ones worth clicking.
+_MORE_ACTIVITIES_JS = r"""
+try {
+  var out = [];
+  var root = document.getElementById('moreactivities');
+  if (!root) return out;
+  var links = root.querySelectorAll('a[href]');
+  for (var i = 0; i < links.length; i++) {
+    var a = links[i];
+    var href = a.href || a.getAttribute('href') || '';
+    if (href.indexOf('bing.com') < 0) continue;
+    // Skip completed cards via their green "success" badge (language-independent).
+    if (a.querySelector('[class*="statusSuccess"]')) continue;
+    var txt = (a.textContent || '').replace(/\s+/g, ' ').trim();
+    var m = txt.match(/\+\s*(\d+)/);
+    if (!m) continue;
+    var tEl = a.querySelector('.text-globalBody2Strong') || a.querySelector('p');
+    var title = tEl ? (tEl.textContent || '').replace(/\s+/g, ' ').trim() : '';
+    out.push({ destination: href, title: title.slice(0, 80), points: parseInt(m[1], 10) });
   }
   return out;
 } catch (e) { return []; }
@@ -137,6 +156,16 @@ class NewDashboardDailySet:
             logger (callable, optional): A function to log messages.
         """
         self.logger = logger
+        # Aggregated counts from the most recent `perform` call, mirroring
+        # DailySet.last_totals so the stats layer can record new-dashboard
+        # runs the same way it records legacy ones.
+        self.last_totals = {
+            "already": 0,
+            "newly": 0,
+            "final": 0,
+            "total": 0,
+            "attempted": 0,
+        }
 
     def _log(self, message):
         if self.logger:
@@ -205,15 +234,15 @@ class NewDashboardDailySet:
 
     # -- Clicking activities ---------------------------------------------------
 
-    def _expand_section(self, driver):
+    def _expand_section(self, driver, section_id="dailyset"):
         """
-        Expand the collapsed "Ensemble du jour" section so its cards become
-        visible and clickable. react-aria marks the Disclosure toggle with
-        slot="trigger"; clicking it when aria-expanded="false" opens the panel.
+        Expand a collapsed section so its cards become visible and clickable.
+        react-aria marks the Disclosure toggle with slot="trigger"; clicking it
+        when aria-expanded="false" opens the panel.
         """
         try:
             triggers = driver.find_elements(
-                By.CSS_SELECTOR, "#dailyset button[slot='trigger']"
+                By.CSS_SELECTOR, f"#{section_id} button[slot='trigger']"
             )
         except Exception:
             return
@@ -225,12 +254,10 @@ class NewDashboardDailySet:
             except Exception:
                 continue
 
-    def _locate_anchor(self, driver, destination, index):
-        """Find the daily-set card <a> for `destination`, else the index-th card."""
+    def _locate_anchor(self, driver, destination, index, section_id="dailyset"):
+        """Find the card <a> for `destination` in a section, else the index-th."""
         try:
-            anchors = driver.find_elements(
-                By.CSS_SELECTOR, "#dailyset a[href*='bing.com/search']"
-            )
+            anchors = driver.find_elements(By.CSS_SELECTOR, f"#{section_id} a[href]")
         except Exception:
             return None
         for a in anchors:
@@ -381,9 +408,112 @@ class NewDashboardDailySet:
         except TimeoutException:
             pass
 
+    def _wait_for(self, driver, selector, timeout=15):
+        """Wait until `selector` matches an element on the page."""
+
+        def _ready(d):
+            try:
+                return bool(
+                    d.execute_script(
+                        "return !!document.querySelector(arguments[0]);", selector
+                    )
+                )
+            except Exception:
+                return False
+
+        try:
+            WebDriverWait(driver, timeout).until(_ready)
+        except TimeoutException:
+            pass
+
     # -- Top-level entry point -------------------------------------------------
 
     def perform(self, driver, human, stop_event=None):
+        """
+        Run the new-dashboard point-earning tasks: the Daily Set (/dashboard) and
+        then the "earn-page" activities (/earn). Returns the Daily Set
+        outcome (used to mark today done); the earn pass is best-effort.
+        """
+        daily_ok = self._run_daily_set(driver, human, stop_event=stop_event)
+        if stop_event is not None and stop_event.is_set():
+            return daily_ok
+        try:
+            self._run_more_activities(driver, human, stop_event=stop_event)
+        except Exception as e:
+            if not (stop_event is not None and stop_event.is_set()):
+                self._log(f"[WARNING] 'earn-page' pass failed: {e}")
+        return daily_ok
+
+    def _run_more_activities(self, driver, human, stop_event=None):
+        """
+        Click the incomplete point-earning cards in the /earn "earn-page"
+        section (#moreactivities). Mirrors the legacy "More Activities" section.
+        """
+        self._log("Checking 'earn-page' activities (new dashboard)")
+        try:
+            driver.get(EARN_URL)
+        except Exception as e:
+            self._log(f"[WARNING] Could not open the earn page: {e}")
+            return
+
+        self._wait_for(driver, "#moreactivities", timeout=15)
+        time.sleep(random.uniform(1.5, 2.5))
+        self._expand_section(driver, "moreactivities")
+        time.sleep(random.uniform(0.5, 1.0))
+
+        try:
+            items = driver.execute_script(_MORE_ACTIVITIES_JS)
+        except Exception as e:
+            self._log(f"[WARNING] Could not read 'earn-page' cards: {e}")
+            return
+        if not isinstance(items, list) or not items:
+            self._log("'earn-page': nothing to do.")
+            return
+
+        self._log(f"'earn-page': {len(items)} activity(ies) to do.")
+        main_tab = driver.current_window_handle
+        done = 0
+        for idx, item in enumerate(items):
+            if stop_event is not None and stop_event.is_set():
+                self._log("Stop requested — halting 'earn-page'.")
+                break
+            dest = item.get("destination")
+            title = item.get("title") or "activity"
+            if not isinstance(dest, str) or not dest.startswith("http"):
+                continue
+            self._log(f"Opening activity: {title} (+{item.get('points')})")
+            anchor = self._locate_anchor(driver, dest, idx, section_id="moreactivities")
+            if anchor is not None and self._click_anchor(
+                driver, human, anchor, main_tab, stop_event
+            ):
+                done += 1
+                continue
+            # Fallback: direct navigation (less likely to credit, but better than skip).
+            self._log(f"[INFO] Falling back to direct navigation for '{title}'.")
+            try:
+                driver.get(dest)
+                done += 1
+                time.sleep(random.uniform(2, 4))
+                try:
+                    human.scroll_page()
+                except Exception:
+                    pass
+                time.sleep(random.uniform(2, 4))
+                driver.get(EARN_URL)
+                self._wait_for(driver, "#moreactivities", timeout=10)
+                time.sleep(random.uniform(1, 2))
+                self._expand_section(driver, "moreactivities")
+            except Exception as e:
+                if stop_event is not None and stop_event.is_set():
+                    break
+                self._log(f"[WARNING] Failed to open '{title}': {e}")
+
+        if done:
+            self.last_totals["newly"] = self.last_totals.get("newly", 0) + done
+            self.last_totals["attempted"] = self.last_totals.get("attempted", 0) + done
+        self._log(f"'earn-page': opened {done} activity(ies) this run.")
+
+    def _run_daily_set(self, driver, human, stop_event=None):
         """
         Open the new dashboard, visit each incomplete daily-set activity for
         today, then re-read to confirm progress.
@@ -442,10 +572,16 @@ class NewDashboardDailySet:
             )
 
             incomplete = [it for it in todays if not it.get("isCompleted")]
-            self._log(
-                f"New dashboard daily set: "
-                f"{len(todays) - len(incomplete)}/{len(todays)} already complete."
-            )
+            total = len(todays)
+            already = total - len(incomplete)
+            self.last_totals = {
+                "already": already,
+                "newly": 0,
+                "final": already,
+                "total": total,
+                "attempted": 0,
+            }
+            self._log(f"New dashboard daily set: {already}/{total} already complete.")
 
             if not incomplete:
                 return True
@@ -530,6 +666,10 @@ class NewDashboardDailySet:
                     newly = max(0, len(incomplete) - still_incomplete)
             except Exception:
                 pass
+
+            self.last_totals["attempted"] = attempted
+            self.last_totals["newly"] = newly
+            self.last_totals["final"] = already + newly
 
             if newly > 0:
                 self._log(f"New dashboard daily set: +{newly} completed this run.")

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -285,16 +285,52 @@ class NewDashboardDailySet:
 
     def _read_items_polling(self, driver, attempts=8, delay=1.5):
         """
-        Poll `_read_items` until items appear. The dashboard streams the daily-set
-        RSC chunk progressively, so it can land a beat after the page's load
-        event; a single read often races ahead of it.
+        Poll `_read_items` until the item set stabilizes. The dashboard streams
+        the daily-set RSC chunks progressively, so an early read can catch a
+        partial payload (e.g. 2 of 3 cards streamed in at that instant);
+        returning on the first non-empty read would silently drop the cards
+        still in flight. Done when the count stops changing between two
+        consecutive reads, or when the payload drains post-hydration (a
+        non-empty snapshot followed by an empty read — nothing more will
+        stream). Always returns the largest snapshot seen.
         """
+        best = []
+        prev_count = None
         for _ in range(max(1, attempts)):
             items = self._read_items(driver)
-            if items:
-                return items
+            if len(items) > len(best):
+                best = items
+            if best and (not items or len(items) == prev_count):
+                return best
+            prev_count = len(items)
             time.sleep(delay)
-        return []
+        return best
+
+    @staticmethod
+    def _choose_today(json_today, dom_today):
+        """
+        Pick the trustworthy "today" card set between the two sources.
+
+        The rendered #dailyset section is ground truth for WHICH cards are
+        today's (it only ever shows today); the RSC JSON is authoritative for
+        completion flags but can be partially streamed — worst case its
+        snapshot holds only another, already-completed day, which would read
+        as "nothing to do" and silently skip (and mark) the whole set.
+
+        Rules: DOM wins when it sees more of today than the JSON group, or
+        when the JSON group shares no destination with the DOM cards (i.e. the
+        JSON group is some other day). Otherwise the JSON group wins.
+
+        Returns:
+            tuple: (items, source) with source "dom" or "json".
+        """
+        if len(dom_today) > len(json_today):
+            return dom_today, "dom"
+        if dom_today:
+            dom_dests = {it.get("destination") for it in dom_today}
+            if not any(it.get("destination") in dom_dests for it in json_today):
+                return dom_today, "dom"
+        return json_today, "json"
 
     def _read_items_dom(self, driver):
         """Fallback: read today's daily-set activities from the rendered DOM."""
@@ -946,19 +982,14 @@ class NewDashboardDailySet:
 
             # Primary: poll the embedded RSC JSON (streams in progressively). It
             # is authoritative — it carries the exact destination + isCompleted.
-            items = self._read_items_polling(driver)
-            source = "json"
-            # Fallback: read today's cards from the rendered #dailyset section.
-            # window.__next_f is normally drained after hydration, so the JSON
-            # path is expected to be empty here — the DOM is the real source at
-            # runtime. A genuine failure (neither path yields cards) is reported
-            # by the "No daily-set activities found" warning below, with the same
-            # diagnostics, so there's nothing to log on this routine fallback.
-            if not items:
-                items = self._read_items_dom(driver)
-                source = "dom"
-
-            todays = self._todays_items(items)
+            # Cross-checked against the rendered #dailyset DOM by _choose_today:
+            # the JSON is often drained post-hydration or partially streamed, so
+            # the DOM decides which cards really are today's. A genuine failure
+            # (neither source yields cards) is reported by the "No daily-set
+            # activities found" warning below.
+            json_today = self._todays_items(self._read_items_polling(driver))
+            dom_today = self._todays_items(self._read_items_dom(driver))
+            todays, source = self._choose_today(json_today, dom_today)
             if not todays:
                 diag = self._diagnostics(driver)
                 self._log(
@@ -1067,8 +1098,12 @@ class NewDashboardDailySet:
                 # cards as we started with — retry (JSON then DOM) until it does.
                 after = []
                 for _ in range(5):
-                    after = self._todays_items(
-                        self._read_items(driver) or self._read_items_dom(driver)
+                    # Same source arbitration as the initial read: a partial
+                    # (or other-day) JSON snapshot must not beat the DOM, or
+                    # missing cards would be counted as completed.
+                    after, _src = self._choose_today(
+                        self._todays_items(self._read_items(driver)),
+                        self._todays_items(self._read_items_dom(driver)),
                     )
                     if len(after) >= len(todays):
                         break

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -18,6 +18,7 @@ import random
 import time
 
 from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 
 DASHBOARD_URL = "https://rewards.bing.com/dashboard"
@@ -202,6 +203,132 @@ class NewDashboardDailySet:
         except Exception as e:
             return {"error": str(e)[:120]}
 
+    # -- Clicking activities ---------------------------------------------------
+
+    def _expand_section(self, driver):
+        """
+        Expand the collapsed "Ensemble du jour" section so its cards become
+        visible and clickable. react-aria marks the Disclosure toggle with
+        slot="trigger"; clicking it when aria-expanded="false" opens the panel.
+        """
+        try:
+            triggers = driver.find_elements(
+                By.CSS_SELECTOR, "#dailyset button[slot='trigger']"
+            )
+        except Exception:
+            return
+        for btn in triggers:
+            try:
+                if (btn.get_attribute("aria-expanded") or "").lower() == "false":
+                    driver.execute_script("arguments[0].click();", btn)
+                    time.sleep(random.uniform(0.6, 1.2))
+            except Exception:
+                continue
+
+    def _locate_anchor(self, driver, destination, index):
+        """Find the daily-set card <a> for `destination`, else the index-th card."""
+        try:
+            anchors = driver.find_elements(
+                By.CSS_SELECTOR, "#dailyset a[href*='bing.com/search']"
+            )
+        except Exception:
+            return None
+        for a in anchors:
+            try:
+                if (a.get_attribute("href") or "") == destination:
+                    return a
+            except Exception:
+                continue
+        if 0 <= index < len(anchors):
+            return anchors[index]
+        return None
+
+    def _click_anchor(self, driver, human, anchor, main_tab, stop_event):
+        """
+        Click a daily-set card the way a user does (a real pointer click that
+        opens the card's new tab from the dashboard) — this is what credits the
+        offer; a bare navigation to the destination URL does not. Handles the new
+        tab (dwell + close) or a same-tab navigation, then returns to the
+        dashboard. Returns True if the click was dispatched and handled.
+        """
+        try:
+            # Skip a card that's momentarily 0x0 (SPA re-render / still collapsed).
+            try:
+                w, h = driver.execute_script(
+                    "const r=arguments[0].getBoundingClientRect();"
+                    "return [r.width, r.height];",
+                    anchor,
+                )
+                if float(w) <= 6 or float(h) <= 6:
+                    return False
+            except Exception:
+                pass
+
+            try:
+                driver.execute_script(
+                    "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
+                    anchor,
+                )
+                time.sleep(random.uniform(0.4, 0.8))
+            except Exception:
+                pass
+
+            before = set(driver.window_handles)
+            cur_url = driver.current_url
+            human.click_element(anchor, scroll_into_view=False)
+            time.sleep(random.uniform(2, 4))
+
+            new_tabs = [
+                x for x in driver.window_handles if x != main_tab and x not in before
+            ]
+            if new_tabs:
+                for tab in new_tabs:
+                    driver.switch_to.window(tab)
+                    # Dwell so the rewards credit beacon on the search page fires.
+                    time.sleep(random.uniform(3, 6))
+                    try:
+                        human.scroll_page()
+                    except Exception:
+                        pass
+                    time.sleep(random.uniform(1, 2))
+                    driver.close()
+                driver.switch_to.window(main_tab)
+                time.sleep(random.uniform(1, 2))
+                return True
+
+            if driver.current_url != cur_url:
+                # Opened in the same tab: dwell, then return to the dashboard.
+                time.sleep(random.uniform(3, 6))
+                try:
+                    human.scroll_page()
+                except Exception:
+                    pass
+                driver.get(DASHBOARD_URL)
+                self._wait_ready(driver)
+                time.sleep(random.uniform(1.5, 2.5))
+                self._expand_section(driver)
+                return True
+
+            # Nothing happened — click missed.
+            return False
+
+        except Exception as e:
+            if stop_event is not None and stop_event.is_set():
+                return False
+            self._log(f"[WARNING] Card click failed: {str(e).splitlines()[0][:140]}")
+            try:
+                for tab in list(driver.window_handles):
+                    if tab != main_tab:
+                        driver.switch_to.window(tab)
+                        driver.close()
+            except Exception:
+                pass
+            try:
+                driver.switch_to.window(main_tab)
+            except Exception:
+                pass
+            return False
+
     @staticmethod
     def _date_key(item):
         """Parse an item's MM/DD/YYYY date into a comparable (Y, M, D) tuple."""
@@ -323,11 +450,20 @@ class NewDashboardDailySet:
             if not incomplete:
                 return True
 
+            # Clicking the card (which opens its search in a new tab from the
+            # dashboard) is what credits the offer — a bare driver.get() to the
+            # destination does not. Expand the section, then click each incomplete
+            # card like a user would.
+            main_tab = driver.current_window_handle
+            self._expand_section(driver)
+
             attempted = 0
-            for item in incomplete:
+            for idx, item in enumerate(todays):
                 if stop_event is not None and stop_event.is_set():
                     self._log("Stop requested — halting new-dashboard daily set.")
                     break
+                if item.get("isCompleted"):
+                    continue
 
                 destination = item.get("destination")
                 title = item.get("title") or item.get("offerId") or "activity"
@@ -338,16 +474,29 @@ class NewDashboardDailySet:
                     continue
 
                 self._log(f"Opening daily-set activity: {title}")
+                anchor = self._locate_anchor(driver, destination, idx)
+                if anchor is not None and self._click_anchor(
+                    driver, human, anchor, main_tab, stop_event
+                ):
+                    attempted += 1
+                    continue
+
+                # Last resort if the card can't be located/clicked: navigate
+                # directly (often won't credit, but better than skipping).
+                self._log(f"[INFO] Falling back to direct navigation for '{title}'.")
                 try:
                     driver.get(destination)
                     attempted += 1
-                    # Dwell like a human reading the results page.
                     time.sleep(random.uniform(2, 4))
                     try:
                         human.scroll_page()
                     except Exception:
                         pass
-                    time.sleep(random.uniform(2, 5))
+                    time.sleep(random.uniform(2, 4))
+                    driver.get(DASHBOARD_URL)
+                    self._wait_ready(driver)
+                    time.sleep(random.uniform(1, 2))
+                    self._expand_section(driver)
                 except Exception as e:
                     if stop_event is not None and stop_event.is_set():
                         break

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -237,13 +237,17 @@ class NewDashboardDailySet:
         self.logger = logger
         # Aggregated counts from the most recent `perform` call, mirroring
         # DailySet.last_totals so the stats layer can record new-dashboard
-        # runs the same way it records legacy ones.
+        # runs the same way it records legacy ones. `newly` counts verified
+        # daily-set completions only; `earn` and `quests` count the /earn cards
+        # and quest tasks opened this run (clicked, not re-verified).
         self.last_totals = {
             "already": 0,
             "newly": 0,
             "final": 0,
             "total": 0,
             "attempted": 0,
+            "earn": 0,
+            "quests": 0,
         }
 
     def _log(self, message):
@@ -778,9 +782,10 @@ class NewDashboardDailySet:
                 self._log(f"[WARNING] Failed to open '{title}': {e}")
 
         if done:
-            # These opens aren't re-read/confirmed, so they count as attempts
-            # only; `newly` stays reserved for verified completions (the
-            # daily-set pass sets it from a completion re-read).
+            # These opens aren't re-read/confirmed, so they count in their own
+            # `earn` bucket (and as attempts); `newly` stays reserved for
+            # verified daily-set completions.
+            self.last_totals["earn"] = self.last_totals.get("earn", 0) + done
             self.last_totals["attempted"] = self.last_totals.get("attempted", 0) + done
         self._log(f"'earn-page': opened {done} activity(ies) this run.")
 
@@ -909,8 +914,9 @@ class NewDashboardDailySet:
                         pass
 
         if opened:
-            # Unverified opens count as attempts only; `newly` is reserved for
-            # verified completions.
+            # Unverified opens count in their own `quests` bucket (and as
+            # attempts); `newly` is reserved for verified completions.
+            self.last_totals["quests"] = self.last_totals.get("quests", 0) + opened
             self.last_totals["attempted"] = (
                 self.last_totals.get("attempted", 0) + opened
             )
@@ -977,6 +983,8 @@ class NewDashboardDailySet:
                 "final": already,
                 "total": total,
                 "attempted": 0,
+                "earn": 0,
+                "quests": 0,
             }
             self._log(f"New dashboard daily set: {already}/{total} already complete.")
 

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -360,15 +360,25 @@ class NewDashboardDailySet:
             if stop_event is not None and stop_event.is_set():
                 return False
 
-            # Re-read the dashboard to measure how many activities are now done.
-            newly = attempted  # optimistic default if the re-read fails
+            # Re-read the dashboard to measure how many activities actually
+            # flipped to complete. window.__next_f is drained after hydration, so
+            # the re-read relies on the same JSON-then-DOM strategy as the initial
+            # read — reading JSON only here would always look "all done" (empty)
+            # and falsely report success.
+            newly = 0
+            verified = False
             try:
                 driver.get(DASHBOARD_URL)
                 self._wait_ready(driver)
                 time.sleep(random.uniform(1.5, 2.5))
-                after = self._todays_items(self._read_items(driver))
-                still_incomplete = sum(1 for it in after if not it.get("isCompleted"))
-                newly = max(0, len(incomplete) - still_incomplete)
+                after_items = self._read_items(driver) or self._read_items_dom(driver)
+                after = self._todays_items(after_items)
+                if after:
+                    verified = True
+                    still_incomplete = sum(
+                        1 for it in after if not it.get("isCompleted")
+                    )
+                    newly = max(0, len(incomplete) - still_incomplete)
             except Exception:
                 pass
 
@@ -376,14 +386,23 @@ class NewDashboardDailySet:
                 self._log(f"New dashboard daily set: +{newly} completed this run.")
                 return True
 
-            # Some activities (quizzes/polls) need manual answers and won't flip
-            # to complete just from opening them. We still opened everything, so
-            # mark today done to avoid pointless retries — mirrors the legacy path.
-            self._log(
-                "[INFO] Daily-set activities opened but none flipped to complete "
-                "(likely quizzes/polls needing manual answers). Marking today done."
-            )
-            return True
+            if verified:
+                # We could re-read the cards and they are still incomplete: the
+                # visits did not credit (common in headless — Rewards often won't
+                # credit a headless session) or the items are quizzes needing
+                # manual answers. Report honestly and don't mark today done, so a
+                # later (visible) run can retry.
+                self._log(
+                    "[WARNING] Daily-set activities were opened but none are marked "
+                    "complete on the dashboard. Not marking today done — if this is "
+                    "a headless run, try again with the browser visible."
+                )
+            else:
+                self._log(
+                    "[WARNING] Could not re-read the dashboard to confirm daily-set "
+                    "completion. Not marking today done."
+                )
+            return False
 
         except Exception as e:
             if stop_event is not None and stop_event.is_set():

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -1,0 +1,272 @@
+"""
+New (Next.js) Microsoft Rewards dashboard — Daily Set handler.
+
+Microsoft's redesigned dashboard is a React/Next.js app: the legacy
+`mee-rewards-*` DOM is gone and its Tailwind class names are obfuscated. But the
+daily-set data is streamed into the page as an RSC payload (`window.__next_f`)
+that contains, for each activity, its `destination` (the Bing search URL the
+card links to), `isCompleted`, `points`, `title` and `date`.
+
+Rather than scrape fragile markup, we read that JSON and then visit each
+incomplete activity's `destination` — the exact URL a real click would open,
+which is what credits the daily-set offer server-side. Completion tracking
+(status.json) is handled by the caller (`DailySet`), so this handler only
+returns whether it's reasonable to mark today as done.
+"""
+
+import random
+import time
+
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.support.ui import WebDriverWait
+
+DASHBOARD_URL = "https://rewards.bing.com"
+
+# Concatenate every streamed RSC chunk (`window.__next_f` is a list of
+# `[1, "<chunk>"]` entries) and pull out each `dailySetItems` array, returning
+# the parsed items to Python. A balanced-bracket scan that respects string
+# literals extracts each array so JSON.parse gets a well-formed slice. The
+# payload may repeat the array across chunks; the Python side dedupes by offerId.
+_EXTRACT_DAILY_SET_JS = r"""
+try {
+  var raw = window.__next_f || [];
+  var parts = [];
+  for (var n = 0; n < raw.length; n++) {
+    var e = raw[n];
+    if (Array.isArray(e)) { if (typeof e[1] === 'string') parts.push(e[1]); }
+    else if (typeof e === 'string') { parts.push(e); }
+  }
+  var blob = parts.join('');
+  var out = [];
+  var key = '"dailySetItems"';
+  var idx = 0;
+  while ((idx = blob.indexOf(key, idx)) !== -1) {
+    var i = blob.indexOf('[', idx + key.length);
+    if (i === -1) break;
+    var depth = 0, inStr = false, esc = false, start = i;
+    for (; i < blob.length; i++) {
+      var c = blob[i];
+      if (inStr) {
+        if (esc) esc = false;
+        else if (c === '\\') esc = true;
+        else if (c === '"') inStr = false;
+      } else {
+        if (c === '"') inStr = true;
+        else if (c === '[') depth++;
+        else if (c === ']') { depth--; if (depth === 0) { i++; break; } }
+      }
+    }
+    try {
+      var arr = JSON.parse(blob.slice(start, i));
+      if (Array.isArray(arr)) { for (var j = 0; j < arr.length; j++) out.push(arr[j]); }
+    } catch (err) { /* skip malformed slice */ }
+    idx = i;
+  }
+  return out;
+} catch (e) { return []; }
+"""
+
+
+class NewDashboardDailySet:
+    """Daily Set handler for the new Next.js Microsoft Rewards dashboard."""
+
+    def __init__(self, logger=None):
+        """
+        Args:
+            logger (callable, optional): A function to log messages.
+        """
+        self.logger = logger
+
+    def _log(self, message):
+        if self.logger:
+            self.logger(message)
+
+    # -- Data extraction -------------------------------------------------------
+
+    def _read_items(self, driver):
+        """Read and dedupe the daily-set items embedded in the current page."""
+        try:
+            raw = driver.execute_script(_EXTRACT_DAILY_SET_JS)
+        except Exception as e:
+            self._log(f"[WARNING] Could not read new-dashboard data: {e}")
+            return []
+
+        if not isinstance(raw, list):
+            return []
+
+        # Dedupe by offerId; prefer the record that reports completion so a
+        # stale "incomplete" copy in another chunk can't re-trigger a visit.
+        by_id = {}
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            key = item.get("offerId") or item.get("hash") or item.get("destination")
+            if key is None:
+                continue
+            prev = by_id.get(key)
+            if prev is None or (
+                item.get("isCompleted") and not prev.get("isCompleted")
+            ):
+                by_id[key] = item
+        return list(by_id.values())
+
+    @staticmethod
+    def _date_key(item):
+        """Parse an item's MM/DD/YYYY date into a comparable (Y, M, D) tuple."""
+        raw = item.get("date")
+        if not isinstance(raw, str):
+            return None
+        parts = raw.split("/")
+        if len(parts) != 3:
+            return None
+        try:
+            month, day, year = (int(p) for p in parts)
+        except ValueError:
+            return None
+        return (year, month, day)
+
+    def _todays_items(self, items):
+        """
+        Return the subset of items for "today".
+
+        The dashboard returns today's set plus a few upcoming days, all of which
+        are `isCompleted: false` until unlocked. Past days are never returned, so
+        the smallest date present is today — using it avoids crediting (locked)
+        future-day activities and sidesteps any client/server timezone mismatch.
+        """
+        keyed = [(self._date_key(it), it) for it in items]
+        dated = [(k, it) for k, it in keyed if k is not None]
+        if not dated:
+            # No parseable dates — fall back to treating everything as today.
+            return items
+        today = min(k for k, _ in dated)
+        return [it for k, it in dated if k == today]
+
+    # -- Navigation helpers ----------------------------------------------------
+
+    def _wait_ready(self, driver, timeout=15):
+        """Wait until the new dashboard has streamed its data / rendered."""
+
+        def _ready(d):
+            try:
+                return bool(
+                    d.execute_script(
+                        "return !!(window.__next_f || document.getElementById('dailyset'));"
+                    )
+                )
+            except Exception:
+                return False
+
+        try:
+            WebDriverWait(driver, timeout).until(_ready)
+        except TimeoutException:
+            pass
+
+    # -- Top-level entry point -------------------------------------------------
+
+    def perform(self, driver, human, stop_event=None):
+        """
+        Open the new dashboard, visit each incomplete daily-set activity for
+        today, then re-read to confirm progress.
+
+        Args:
+            driver: Selenium WebDriver instance.
+            human: HumanBehavior instance (used for human-like dwell/scroll).
+            stop_event (threading.Event, optional): When set, aborts cleanly.
+
+        Returns:
+            bool: True if it's reasonable to mark today as done, False if we made
+                  no progress (so the next run can retry).
+        """
+        self._log("Performing daily Rewards tasks (new dashboard)")
+
+        try:
+            driver.get(DASHBOARD_URL)
+            self._wait_ready(driver)
+            # Brief settle so late RSC chunks finish streaming in.
+            time.sleep(random.uniform(2, 3))
+
+            todays = self._todays_items(self._read_items(driver))
+            if not todays:
+                self._log(
+                    "[WARNING] No daily-set activities found in the new dashboard."
+                )
+                return False
+
+            incomplete = [it for it in todays if not it.get("isCompleted")]
+            self._log(
+                f"New dashboard daily set: "
+                f"{len(todays) - len(incomplete)}/{len(todays)} already complete."
+            )
+
+            if not incomplete:
+                return True
+
+            attempted = 0
+            for item in incomplete:
+                if stop_event is not None and stop_event.is_set():
+                    self._log("Stop requested — halting new-dashboard daily set.")
+                    break
+
+                destination = item.get("destination")
+                title = item.get("title") or item.get("offerId") or "activity"
+                if not isinstance(destination, str) or not destination.startswith(
+                    "http"
+                ):
+                    self._log(f"[WARNING] Skipping '{title}': no valid destination.")
+                    continue
+
+                self._log(f"Opening daily-set activity: {title}")
+                try:
+                    driver.get(destination)
+                    attempted += 1
+                    # Dwell like a human reading the results page.
+                    time.sleep(random.uniform(2, 4))
+                    try:
+                        human.scroll_page()
+                    except Exception:
+                        pass
+                    time.sleep(random.uniform(2, 5))
+                except Exception as e:
+                    if stop_event is not None and stop_event.is_set():
+                        break
+                    self._log(f"[WARNING] Failed to open '{title}': {e}")
+
+            if attempted == 0:
+                self._log("[WARNING] No daily-set activities could be opened.")
+                return False
+
+            if stop_event is not None and stop_event.is_set():
+                return False
+
+            # Re-read the dashboard to measure how many activities are now done.
+            newly = attempted  # optimistic default if the re-read fails
+            try:
+                driver.get(DASHBOARD_URL)
+                self._wait_ready(driver)
+                time.sleep(random.uniform(1.5, 2.5))
+                after = self._todays_items(self._read_items(driver))
+                still_incomplete = sum(1 for it in after if not it.get("isCompleted"))
+                newly = max(0, len(incomplete) - still_incomplete)
+            except Exception:
+                pass
+
+            if newly > 0:
+                self._log(f"New dashboard daily set: +{newly} completed this run.")
+                return True
+
+            # Some activities (quizzes/polls) need manual answers and won't flip
+            # to complete just from opening them. We still opened everything, so
+            # mark today done to avoid pointless retries — mirrors the legacy path.
+            self._log(
+                "[INFO] Daily-set activities opened but none flipped to complete "
+                "(likely quizzes/polls needing manual answers). Marking today done."
+            )
+            return True
+
+        except Exception as e:
+            if stop_event is not None and stop_event.is_set():
+                self._log("New-dashboard daily set halted by Stop.")
+                return False
+            self._log(f"[ERROR] New-dashboard daily set failed: {e}")
+            return False

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -66,6 +66,60 @@ try {
 } catch (e) { return []; }
 """
 
+# DOM fallback: read today's daily-set activities straight from the rendered
+# `#dailyset` section when the RSC JSON isn't available. The section holds only
+# today's cards, each an <a> pointing at the Bing search that credits it. We
+# best-effort detect completion from a small set of localized "done" words; when
+# unsure we treat the card as incomplete (re-opening a completed daily search is
+# harmless).
+_DOM_DAILY_SET_JS = r"""
+try {
+  var out = [];
+  var root = document.getElementById('dailyset');
+  if (!root) return out;
+  var doneWords = ['terminé','termine','completed','complete','done','erledigt',
+    'abgeschlossen','completado','completada','completato','concluído','voltooid',
+    'terminado','fait'];
+  var links = root.querySelectorAll('a[href]');
+  for (var i = 0; i < links.length; i++) {
+    var a = links[i];
+    var href = a.href || a.getAttribute('href') || '';
+    if (href.indexOf('bing.com') < 0 && href.indexOf('/search') < 0) continue;
+    var txt = (a.textContent || '').replace(/\s+/g, ' ').trim();
+    var low = txt.toLowerCase();
+    var done = false;
+    for (var d = 0; d < doneWords.length; d++) {
+      if (low.indexOf(doneWords[d]) >= 0) { done = true; break; }
+    }
+    out.push({ destination: href, title: txt.slice(0, 60), isCompleted: done, date: null });
+  }
+  return out;
+} catch (e) { return []; }
+"""
+
+# Diagnostic snapshot logged when no activities are found, so a failure can be
+# understood from the logs (did the RSC chunk stream in? is the section there?).
+_DIAG_JS = r"""
+try {
+  var chunks = window.__next_f || [];
+  var parts = [];
+  for (var n = 0; n < chunks.length; n++) {
+    var e = chunks[n];
+    if (Array.isArray(e)) { if (typeof e[1] === 'string') parts.push(e[1]); }
+    else if (typeof e === 'string') { parts.push(e); }
+  }
+  var blob = parts.join('');
+  return {
+    chunks: chunks.length,
+    blobLen: blob.length,
+    hasKey: blob.indexOf('"dailySetItems"') >= 0,
+    hasDailyset: !!document.getElementById('dailyset'),
+    url: location.href,
+    title: document.title
+  };
+} catch (e) { return { error: String(e).slice(0, 120) }; }
+"""
+
 
 class NewDashboardDailySet:
     """Daily Set handler for the new Next.js Microsoft Rewards dashboard."""
@@ -109,6 +163,38 @@ class NewDashboardDailySet:
             ):
                 by_id[key] = item
         return list(by_id.values())
+
+    def _read_items_polling(self, driver, attempts=8, delay=1.5):
+        """
+        Poll `_read_items` until items appear. The dashboard streams the daily-set
+        RSC chunk progressively, so it can land a beat after the page's load
+        event; a single read often races ahead of it.
+        """
+        for _ in range(max(1, attempts)):
+            items = self._read_items(driver)
+            if items:
+                return items
+            time.sleep(delay)
+        return []
+
+    def _read_items_dom(self, driver):
+        """Fallback: read today's daily-set activities from the rendered DOM."""
+        try:
+            raw = driver.execute_script(_DOM_DAILY_SET_JS)
+        except Exception as e:
+            self._log(f"[WARNING] Could not read new-dashboard DOM: {e}")
+            return []
+        if not isinstance(raw, list):
+            return []
+        return [it for it in raw if isinstance(it, dict) and it.get("destination")]
+
+    def _diagnostics(self, driver):
+        """Return a small diagnostic dict about the current page (for logging)."""
+        try:
+            info = driver.execute_script(_DIAG_JS)
+            return info if isinstance(info, dict) else {}
+        except Exception as e:
+            return {"error": str(e)[:120]}
 
     @staticmethod
     def _date_key(item):
@@ -186,12 +272,29 @@ class NewDashboardDailySet:
             # Brief settle so late RSC chunks finish streaming in.
             time.sleep(random.uniform(2, 3))
 
-            todays = self._todays_items(self._read_items(driver))
+            # Primary: poll the embedded RSC JSON (streams in progressively).
+            items = self._read_items_polling(driver)
+            source = "json"
+            # Fallback: read today's cards from the rendered #dailyset section.
+            if not items:
+                items = self._read_items_dom(driver)
+                source = "dom"
+
+            todays = self._todays_items(items)
             if not todays:
+                diag = self._diagnostics(driver)
                 self._log(
-                    "[WARNING] No daily-set activities found in the new dashboard."
+                    "[WARNING] No daily-set activities found in the new dashboard — "
+                    f"url={diag.get('url')!r} title={diag.get('title')!r} "
+                    f"chunks={diag.get('chunks')} blobLen={diag.get('blobLen')} "
+                    f"hasDailySetItems={diag.get('hasKey')} "
+                    f"hasDailysetSection={diag.get('hasDailyset')}"
                 )
                 return False
+
+            self._log(
+                f"New dashboard daily set: read {len(todays)} item(s) via {source}."
+            )
 
             incomplete = [it for it in todays if not it.get("isCompleted")]
             self._log(

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -142,11 +142,26 @@ try {
     var key = href.split('?')[0].split('#')[0];
     if (seen[key]) continue;
     seen[key] = 1;
-    var txt = (a.textContent || '').replace(/\s+/g, ' ').trim();
-    var pts = 0; var pm = txt.match(/\+\s*(\d+)/); if (pm) pts = parseInt(pm[1], 10);
+    // Read points and progress from their own elements — NOT the card's
+    // concatenated textContent, where adjacent nodes like "+50" and "1/4" merge
+    // into "+501/4" and get misparsed. The informative-tint badge shows points
+    // to earn; the success badge shows points already earned on a done quest.
+    var pts = 0;
+    var badge = a.querySelector('[class*="statusInformativeTintFg"]')
+             || a.querySelector('[class*="statusSuccess"]');
+    if (badge) {
+      var bm = (badge.textContent || '').match(/(\d+)/);
+      if (bm) pts = parseInt(bm[1], 10);
+    }
+    // Progress "N/M": the leaf node whose own text IS a fraction (never merged
+    // with the neighbouring points badge).
     var done = null, total = null;
-    var prog = txt.match(/(\d+)\s*\/\s*(\d+)/);
-    if (prog) { done = parseInt(prog[1], 10); total = parseInt(prog[2], 10); }
+    var nodes = a.querySelectorAll('*');
+    for (var k = 0; k < nodes.length; k++) {
+      if (nodes[k].children.length) continue;
+      var pm = (nodes[k].textContent || '').match(/(\d+)\s*\/\s*(\d+)/);
+      if (pm) { done = parseInt(pm[1], 10); total = parseInt(pm[2], 10); break; }
+    }
     var tEl = a.querySelector('.text-globalBody2Strong') || a.querySelector('p');
     var title = tEl ? (tEl.textContent || '').replace(/\s+/g, ' ').trim() : '';
     out.push({ url: key, title: title.slice(0, 80), points: pts, done: done, total: total });
@@ -170,11 +185,17 @@ try {
     if ((el.getAttribute('aria-disabled') || '') === 'true') continue;
     if ((el.getAttribute('data-disabled') || '') === 'true') continue;
     if (el.hasAttribute('disabled')) continue;
-    var href = el.getAttribute('href') || '';
+    // For an <a> el.href is the resolved absolute URL, matching Selenium's
+    // get_attribute('href') used to relocate it; a <span role="link"> has no
+    // .href property so we keep its raw attribute (also what Selenium returns).
+    var href = el.href || el.getAttribute('href') || '';
     if (!href) continue;
     var row = el.closest('div');
     var tEl = row ? row.querySelector('h3, .text-globalBody2Strong') : null;
     var title = tEl ? (tEl.textContent || '').replace(/\s+/g, ' ').trim() : '';
+    // The heading ends with a call-to-action sentence (e.g. "... Click to
+    // complete."); keep only the first sentence. Language-independent.
+    title = title.split('. ')[0].trim();
     out.push({ destination: href, title: title.slice(0, 80) });
   }
   return out;
@@ -309,6 +330,24 @@ class NewDashboardDailySet:
                 if (btn.get_attribute("aria-expanded") or "").lower() == "false":
                     driver.execute_script("arguments[0].click();", btn)
                     time.sleep(random.uniform(0.6, 1.2))
+            except Exception:
+                continue
+
+    def _expand_all(self, driver):
+        """
+        Expand every collapsed react-aria disclosure on the page. Used on /earn,
+        where quest punchcards live in their own collapsible panel (not
+        #moreactivities) and would otherwise stay unrendered/undiscovered.
+        """
+        try:
+            triggers = driver.find_elements(By.CSS_SELECTOR, "button[slot='trigger']")
+        except Exception:
+            return
+        for btn in triggers:
+            try:
+                if (btn.get_attribute("aria-expanded") or "").lower() == "false":
+                    driver.execute_script("arguments[0].click();", btn)
+                    time.sleep(random.uniform(0.3, 0.6))
             except Exception:
                 continue
 
@@ -513,7 +552,7 @@ class NewDashboardDailySet:
             pass
 
     def _wait_for(self, driver, selector, timeout=15):
-        """Wait until `selector` matches an element on the page."""
+        """Wait until `selector` matches an element. Returns True if it appeared."""
 
         def _ready(d):
             try:
@@ -527,8 +566,9 @@ class NewDashboardDailySet:
 
         try:
             WebDriverWait(driver, timeout).until(_ready)
+            return True
         except TimeoutException:
-            pass
+            return False
 
     # -- Top-level entry point -------------------------------------------------
 
@@ -647,25 +687,34 @@ class NewDashboardDailySet:
         try:
             driver.get(EARN_URL)
             self._wait_ready(driver)
-            time.sleep(random.uniform(1.5, 2.5))
         except Exception as e:
             self._log(f"[WARNING] Could not open the earn page for quests: {e}")
             return
 
-        # Expand collapsible sections so lazily-rendered quest cards materialize.
-        self._expand_section(driver, "moreactivities")
-        time.sleep(random.uniform(0.5, 1.0))
-
-        try:
-            quests = driver.execute_script(_QUESTS_JS)
-        except Exception as e:
-            self._log(f"[WARNING] Could not read quests: {e}")
-            return
-        if not isinstance(quests, list) or not quests:
+        # Quest cards sit in a collapsible panel and stream in progressively.
+        # Expand every collapsed section, then poll discovery until the set of
+        # quests stops growing so a late-rendered card isn't missed.
+        self._expand_all(driver)
+        quests = []
+        for _ in range(6):
+            time.sleep(random.uniform(0.8, 1.4))
+            try:
+                current = driver.execute_script(_QUESTS_JS) or []
+            except Exception as e:
+                self._log(f"[WARNING] Could not read quests: {e}")
+                return
+            if isinstance(current, list) and len(current) > len(quests):
+                quests = current
+            elif quests:
+                break
+        if not quests:
             self._log("Quests: none found.")
             return
 
-        # Skip quests already fully complete (progress N/N).
+        # Keep only quests that award points and aren't finished. Points-earning
+        # quests carry a "+N" badge on their card; promo quests (partner offers,
+        # e.g. Spotify/MasterClass) show none and are skipped, as are quests
+        # already complete (progress N/N).
         pending = []
         for q in quests:
             if not isinstance(q, dict):
@@ -673,16 +722,19 @@ class NewDashboardDailySet:
             url = q.get("url")
             if not isinstance(url, str) or "/earn/quest/" not in url:
                 continue
+            pts = q.get("points")
+            if not isinstance(pts, int) or pts <= 0:
+                continue
             d, t = q.get("done"), q.get("total")
             if isinstance(d, int) and isinstance(t, int) and t > 0 and d >= t:
                 continue
             pending.append(q)
 
         if not pending:
-            self._log("Quests: all complete.")
+            self._log("Quests: no points-earning quest to do.")
             return
 
-        self._log(f"Quests: {len(pending)} incomplete quest(s) to check.")
+        self._log(f"Quests: {len(pending)} points-earning quest(s) to check.")
         main_tab = driver.current_window_handle
         opened = 0
         for q in pending:
@@ -694,10 +746,20 @@ class NewDashboardDailySet:
             try:
                 driver.get(url)
                 self._wait_ready(driver)
-                time.sleep(random.uniform(1.5, 2.5))
             except Exception as e:
                 self._log(f"[WARNING] Could not open quest '{title}': {e}")
                 continue
+
+            # The task list streams in after hydration; _wait_ready only gates on
+            # the Next.js payload existing. Wait for a task heading to render
+            # before reading, so a not-yet-loaded list isn't mistaken for
+            # "nothing to do" (which would skip an unlocked task).
+            if not self._wait_for(
+                driver, '[class*="rewardsTableAltBg"] h3', timeout=15
+            ):
+                self._log(f"Quest '{title}': task list did not render — skipping.")
+                continue
+            time.sleep(random.uniform(1.0, 1.8))
 
             try:
                 tasks = driver.execute_script(_QUEST_TASKS_JS)

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -575,10 +575,18 @@ class NewDashboardDailySet:
     def perform(self, driver, human, stop_event=None):
         """
         Run the new-dashboard point-earning tasks: the Daily Set (/dashboard),
-        the "earn-page" activities and the quests (/earn). Returns the Daily Set
-        outcome (used to mark today done); the earn/quest passes are best-effort.
+        claiming pending points, then the "earn-page" activities and the quests
+        (/earn). Returns the Daily Set outcome (used to mark today done); the
+        claim/earn/quest passes are best-effort.
         """
         daily_ok = self._run_daily_set(driver, human, stop_event=stop_event)
+        if stop_event is not None and stop_event.is_set():
+            return daily_ok
+        try:
+            self._run_claim(driver, human, stop_event=stop_event)
+        except Exception as e:
+            if not (stop_event is not None and stop_event.is_set()):
+                self._log(f"[WARNING] Claim pass failed: {e}")
         if stop_event is not None and stop_event.is_set():
             return daily_ok
         try:
@@ -594,6 +602,110 @@ class NewDashboardDailySet:
             if not (stop_event is not None and stop_event.is_set()):
                 self._log(f"[WARNING] Quest pass failed: {e}")
         return daily_ok
+
+    def _run_claim(self, driver, human, stop_event=None):
+        """
+        Claim pending points from the dashboard "ready to claim" tile.
+
+        New-dashboard points must be claimed before they count toward the balance
+        (and they expire ~1 month after being earned). The tile shows a pending
+        count with a danger dot; clicking it opens a flyout whose primary button
+        claims them. Best-effort and language-independent — matched by the
+        coins-icon asset, the danger-status token and the brand-button token,
+        never by localized labels.
+        """
+        self._log("Checking for claimable points (new dashboard)")
+        try:
+            driver.get(DASHBOARD_URL)
+            self._wait_ready(driver)
+            time.sleep(random.uniform(1.5, 2.5))
+        except Exception as e:
+            self._log(f"[WARNING] Could not open the dashboard to claim: {e}")
+            return
+
+        # The claim tile: a clickable (non-link) card with the coins icon and a
+        # danger-status dot (pending points). The balance tile also shows a coins
+        # icon but is an <a href="/redeem"> with no danger dot, so it's excluded.
+        card = None
+        pending = ""
+        try:
+            icons = driver.find_elements(
+                By.CSS_SELECTOR, 'img[src*="CoinsTransparent"]'
+            )
+        except Exception:
+            icons = []
+        for icon in icons:
+            try:
+                anc = icon.find_element(
+                    By.XPATH,
+                    "./ancestor::*[contains(@class,'cursor-pointer')][1]",
+                )
+                if anc.tag_name.lower() == "a":
+                    continue
+                if not anc.find_elements(By.CSS_SELECTOR, '[class*="statusDanger"]'):
+                    continue
+                card = anc
+                try:
+                    pending = anc.find_element(
+                        By.CSS_SELECTOR, ".text-pageHeader"
+                    ).text.strip()
+                except Exception:
+                    pending = ""
+                break
+            except Exception:
+                continue
+
+        if card is None:
+            self._log("No claimable points.")
+            return
+
+        self._log(f"Opening claim flyout (pending: {pending or '?'} points).")
+        try:
+            driver.execute_script(
+                "arguments[0].scrollIntoView({block:'center'});", card
+            )
+            time.sleep(random.uniform(0.4, 0.8))
+            human.click_element(card, scroll_into_view=False)
+        except Exception as e:
+            if stop_event is not None and stop_event.is_set():
+                return
+            self._log(f"[WARNING] Could not open the claim flyout: {e}")
+            return
+
+        # Wait for the flyout, then click its primary (brand) button — not the
+        # close (slot="close") or the "how it works" disclosure (slot="trigger").
+        if not self._wait_for(driver, '[class*="bg-flyout"]', timeout=10):
+            self._log("[WARNING] Claim flyout did not open.")
+            return
+        time.sleep(random.uniform(0.8, 1.4))
+        try:
+            flyout = driver.find_element(By.CSS_SELECTOR, '[class*="bg-flyout"]')
+            btn = None
+            for b in flyout.find_elements(
+                By.CSS_SELECTOR, 'button[class*="bgCtrlBrandRest"]'
+            ):
+                if b.get_attribute("slot"):
+                    continue
+                if not b.is_enabled():
+                    continue
+                btn = b
+                break
+        except Exception as e:
+            self._log(f"[WARNING] Could not find the claim button: {e}")
+            return
+
+        if btn is None:
+            self._log("[WARNING] Claim button not found in the flyout.")
+            return
+        try:
+            human.click_element(btn, scroll_into_view=True)
+            time.sleep(random.uniform(1.5, 2.5))
+            self.last_totals["attempted"] = self.last_totals.get("attempted", 0) + 1
+            self._log("Clicked claim — pending points submitted.")
+        except Exception as e:
+            if stop_event is not None and stop_event.is_set():
+                return
+            self._log(f"[WARNING] Could not click the claim button: {e}")
 
     def _run_more_activities(self, driver, human, stop_event=None):
         """
@@ -831,18 +943,12 @@ class NewDashboardDailySet:
             items = self._read_items_polling(driver)
             source = "json"
             # Fallback: read today's cards from the rendered #dailyset section.
+            # window.__next_f is normally drained after hydration, so the JSON
+            # path is expected to be empty here — the DOM is the real source at
+            # runtime. A genuine failure (neither path yields cards) is reported
+            # by the "No daily-set activities found" warning below, with the same
+            # diagnostics, so there's nothing to log on this routine fallback.
             if not items:
-                # Always log why the JSON path came up empty, even when the DOM
-                # fallback succeeds, so we can tell "chunk not streamed yet" from
-                # "extraction bug" without another round-trip.
-                diag = self._diagnostics(driver)
-                self._log(
-                    "[INFO] New-dashboard JSON had no daily-set items — "
-                    f"chunks={diag.get('chunks')} blobLen={diag.get('blobLen')} "
-                    f"hasDailySetItems={diag.get('hasKey')} "
-                    f"hasDailysetSection={diag.get('hasDailyset')} "
-                    f"url={diag.get('url')!r}"
-                )
                 items = self._read_items_dom(driver)
                 source = "dom"
 

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -20,7 +20,7 @@ import time
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.ui import WebDriverWait
 
-DASHBOARD_URL = "https://rewards.bing.com"
+DASHBOARD_URL = "https://rewards.bing.com/dashboard"
 
 # Concatenate every streamed RSC chunk (`window.__next_f` is a list of
 # `[1, "<chunk>"]` entries) and pull out each `dailySetItems` array, returning

--- a/src/dailytasks/runner.py
+++ b/src/dailytasks/runner.py
@@ -90,6 +90,8 @@ class DailySet:
             "final": 0,
             "total": 0,
             "attempted": 0,
+            "earn": 0,
+            "quests": 0,
         }
 
     def _log(self, message):
@@ -364,6 +366,8 @@ class DailySet:
             "final": 0,
             "total": 0,
             "attempted": 0,
+            "earn": 0,
+            "quests": 0,
         }
 
         variant = variant or self.dashboard_variant or "auto"
@@ -450,6 +454,8 @@ class DailySet:
             "final": 0,
             "total": 0,
             "attempted": 0,
+            "earn": 0,
+            "quests": 0,
         }
 
         try:

--- a/src/dailytasks/runner.py
+++ b/src/dailytasks/runner.py
@@ -40,6 +40,21 @@ SECTIONS = (
 # loaded properly.
 ANY_CARD_SELECTOR = ", ".join(sel for _, sel in SECTIONS)
 
+# Both the legacy and the new (Next.js) dashboards live at this URL; a migrated
+# account is redirected to the new /dashboard automatically.
+DASHBOARD_URL = "https://rewards.bing.com"
+
+# JS booleans used to tell which dashboard actually rendered (for variant="auto").
+# The legacy dashboard exposes `mee-rewards-*` Angular custom elements; the new
+# one is a Next.js app that streams its data into `window.__next_f` and renders
+# a `#dailyset` section.
+_IS_LEGACY_JS = (
+    "return !!(document.querySelector('mee-rewards-daily-set-item-content')"
+    " || document.querySelector('mee-rewards-more-activities-card-item')"
+    " || document.querySelector('mee-rewards-more-activities-card'));"
+)
+_IS_NEW_JS = "return !!(window.__next_f || document.getElementById('dailyset'));"
+
 
 class DailySet:
     """
@@ -47,14 +62,20 @@ class DailySet:
     scoped to one account.
     """
 
-    def __init__(self, status_file, logger=None):
+    def __init__(self, status_file, logger=None, dashboard_variant="auto"):
         """
         Args:
             status_file (str): Absolute path to this account's status.json.
             logger (callable, optional): A function to log messages. Defaults to None.
+            dashboard_variant (str): Which Rewards dashboard this account uses —
+                "auto" (detect at runtime), "legacy" (mee-rewards-* DOM), or
+                "new" (Next.js dashboard). Acts as the default; the value passed
+                to `perform_daily_set` takes precedence so runtime changes to the
+                per-account setting are honored.
         """
         self.status_file = status_file
         self.logger = logger
+        self.dashboard_variant = dashboard_variant
         # Filled in on each `perform_daily_set` call after the driver is ready.
         self.cards = None
         # Aggregated card counts from the most recent perform_daily_set call,
@@ -315,19 +336,81 @@ class DailySet:
 
     # -- Top-level entry point -------------------------------------------------
 
-    def perform_daily_set(self, driver, human, stop_event=None):
+    def perform_daily_set(self, driver, human, stop_event=None, variant=None):
         """
-        Visit the Rewards dashboard and process every click-through task we
-        know about: the Daily Set and the "More Activities" / "Plus d'activité"
-        section. Cards already marked complete are skipped, and each clicked
-        card's status is re-checked after the run to validate progress.
+        Run the Daily Set for this account, dispatching to the legacy or the
+        new-dashboard handler based on the resolved dashboard variant.
 
         Args:
             driver: Selenium WebDriver instance.
             human: An instance of HumanBehavior for performing human-like interactions.
-            stop_event (threading.Event, optional): When set, the per-section
-                card loop breaks at the next iteration so the run aborts
-                cleanly without re-clicking remaining cards.
+            stop_event (threading.Event, optional): When set, the run aborts cleanly.
+            variant (str, optional): Overrides the instance's dashboard_variant
+                ("auto"/"legacy"/"new"). When None, falls back to the value set
+                on the instance. "auto" detects which dashboard rendered.
+
+        Returns:
+            bool: True if it's reasonable to mark today as done, False if we
+                  made no progress (so the next run can retry).
+        """
+        variant = variant or self.dashboard_variant or "auto"
+
+        if variant == "auto":
+            variant = self._detect_variant(driver)
+            self._log(f"Auto-detected Rewards dashboard: {variant}")
+
+        if variant == "new":
+            from .new_dashboard import NewDashboardDailySet
+
+            return NewDashboardDailySet(logger=self.logger).perform(
+                driver, human, stop_event=stop_event
+            )
+
+        return self._perform_legacy(driver, human, stop_event=stop_event)
+
+    def _detect_variant(self, driver):
+        """
+        Load the dashboard and report which variant rendered: "legacy" or "new".
+
+        Navigates to DASHBOARD_URL, waits until either dashboard's signature is
+        present, and returns "legacy" for the mee-rewards-* DOM or "new" for the
+        Next.js app. Falls back to "legacy" if neither is detected (the legacy
+        path fails loudly, which is the safer default for an unknown page).
+        """
+        try:
+            driver.get(DASHBOARD_URL)
+        except Exception as e:
+            self._log(f"[WARNING] Could not open the dashboard for detection: {e}")
+            return "legacy"
+
+        def _ready(d):
+            try:
+                return bool(d.execute_script(_IS_LEGACY_JS)) or bool(
+                    d.execute_script(_IS_NEW_JS)
+                )
+            except Exception:
+                return False
+
+        try:
+            WebDriverWait(driver, 15).until(_ready)
+        except TimeoutException:
+            pass
+
+        try:
+            if driver.execute_script(_IS_LEGACY_JS):
+                return "legacy"
+            if driver.execute_script(_IS_NEW_JS):
+                return "new"
+        except Exception:
+            pass
+        return "legacy"
+
+    def _perform_legacy(self, driver, human, stop_event=None):
+        """
+        Visit the legacy Rewards dashboard and process every click-through task
+        we know about: the Daily Set and the "More Activities" / "Plus
+        d'activité" section. Cards already marked complete are skipped, and each
+        clicked card's status is re-checked after the run to validate progress.
 
         Returns:
             bool: True if it's reasonable to mark today as done — either all
@@ -350,7 +433,7 @@ class DailySet:
         }
 
         try:
-            driver.get("https://rewards.bing.com")
+            driver.get(DASHBOARD_URL)
 
             # Wait for at least one card from any tracked section to render.
             try:

--- a/src/dailytasks/runner.py
+++ b/src/dailytasks/runner.py
@@ -356,6 +356,16 @@ class DailySet:
             bool: True if it's reasonable to mark today as done, False if we
                   made no progress (so the next run can retry).
         """
+        # Reset here so every path (legacy, new, aborted-early) starts from
+        # zeros and the stats layer never folds in counts from a prior run.
+        self.last_totals = {
+            "already": 0,
+            "newly": 0,
+            "final": 0,
+            "total": 0,
+            "attempted": 0,
+        }
+
         variant = variant or self.dashboard_variant or "auto"
 
         if variant == "auto":
@@ -365,9 +375,12 @@ class DailySet:
         if variant == "new":
             from .new_dashboard import NewDashboardDailySet
 
-            return NewDashboardDailySet(logger=self.logger).perform(
-                driver, human, stop_event=stop_event
-            )
+            handler = NewDashboardDailySet(logger=self.logger)
+            result = handler.perform(driver, human, stop_event=stop_event)
+            # Surface the new-dashboard run's counts for the stats layer so
+            # per-account statistics stay accurate on migrated accounts.
+            self.last_totals = dict(handler.last_totals)
+            return result
 
         return self._perform_legacy(driver, human, stop_event=stop_event)
 

--- a/src/dailytasks/runner.py
+++ b/src/dailytasks/runner.py
@@ -41,8 +41,11 @@ SECTIONS = (
 ANY_CARD_SELECTOR = ", ".join(sel for _, sel in SECTIONS)
 
 # Both the legacy and the new (Next.js) dashboards live at this URL; a migrated
-# account is redirected to the new /dashboard automatically.
+# account is redirected to the new /dashboard automatically. The legacy Angular
+# dashboard renders at the root; the new Next.js dashboard lives at /dashboard,
+# so auto-detection probes the root first and falls back to /dashboard.
 DASHBOARD_URL = "https://rewards.bing.com"
+NEW_DASHBOARD_URL = "https://rewards.bing.com/dashboard"
 
 # JS booleans used to tell which dashboard actually rendered (for variant="auto").
 # The legacy dashboard exposes `mee-rewards-*` Angular custom elements; the new
@@ -372,16 +375,12 @@ class DailySet:
         """
         Load the dashboard and report which variant rendered: "legacy" or "new".
 
-        Navigates to DASHBOARD_URL, waits until either dashboard's signature is
-        present, and returns "legacy" for the mee-rewards-* DOM or "new" for the
-        Next.js app. Falls back to "legacy" if neither is detected (the legacy
-        path fails loudly, which is the safer default for an unknown page).
+        Probes the root (legacy Angular dashboard) first; if neither signature
+        appears there, retries at /dashboard (the new Next.js app, which the root
+        may not redirect to for a headless session). Returns "legacy" for the
+        mee-rewards-* DOM or "new" for the Next.js app, defaulting to "legacy" if
+        neither is detected (the legacy path fails loudly — the safer default).
         """
-        try:
-            driver.get(DASHBOARD_URL)
-        except Exception as e:
-            self._log(f"[WARNING] Could not open the dashboard for detection: {e}")
-            return "legacy"
 
         def _ready(d):
             try:
@@ -391,18 +390,26 @@ class DailySet:
             except Exception:
                 return False
 
-        try:
-            WebDriverWait(driver, 15).until(_ready)
-        except TimeoutException:
-            pass
+        for url in (DASHBOARD_URL, NEW_DASHBOARD_URL):
+            try:
+                driver.get(url)
+            except Exception as e:
+                self._log(f"[WARNING] Could not open {url} for detection: {e}")
+                continue
 
-        try:
-            if driver.execute_script(_IS_LEGACY_JS):
-                return "legacy"
-            if driver.execute_script(_IS_NEW_JS):
-                return "new"
-        except Exception:
-            pass
+            try:
+                WebDriverWait(driver, 15).until(_ready)
+            except TimeoutException:
+                pass
+
+            try:
+                if driver.execute_script(_IS_LEGACY_JS):
+                    return "legacy"
+                if driver.execute_script(_IS_NEW_JS):
+                    return "new"
+            except Exception:
+                pass
+
         return "legacy"
 
     def _perform_legacy(self, driver, human, stop_event=None):

--- a/src/stats/manager.py
+++ b/src/stats/manager.py
@@ -216,6 +216,8 @@ class StatsManager:
                 "pc_searches": 0,
                 "mobile_searches": 0,
                 "daily_cards": 0,
+                "earn_cards": 0,
+                "quest_tasks": 0,
                 "runs": 0,
                 "points_estimate": 0,
             },
@@ -232,6 +234,8 @@ class StatsManager:
                 "pc_searches": 0,
                 "mobile_searches": 0,
                 "daily_cards": 0,
+                "earn_cards": 0,
+                "quest_tasks": 0,
                 "points_estimate": 0,
                 "points_delta": None,
             },
@@ -350,7 +354,13 @@ class StatsManager:
         return stats
 
     def record_session(
-        self, pc_searches=0, mobile_searches=0, daily_cards=0, balance=None
+        self,
+        pc_searches=0,
+        mobile_searches=0,
+        daily_cards=0,
+        earn_cards=0,
+        quest_tasks=0,
+        balance=None,
     ):
         """
         Record one completed run: bump lifetime counters, refresh the
@@ -360,7 +370,9 @@ class StatsManager:
         Args:
             pc_searches (int): successful PC searches this run.
             mobile_searches (int): successful Mobile searches this run.
-            daily_cards (int): Daily Set / More Activities cards newly completed.
+            daily_cards (int): Daily Set cards newly completed (verified).
+            earn_cards (int): /earn point-earning cards opened this run.
+            quest_tasks (int): quest punchcard tasks opened this run.
             balance (int | None): scraped real balance, or None if unavailable.
 
         Returns:
@@ -369,23 +381,34 @@ class StatsManager:
         pc = max(0, int(pc_searches or 0))
         mobile = max(0, int(mobile_searches or 0))
         cards = max(0, int(daily_cards or 0))
+        earn = max(0, int(earn_cards or 0))
+        quests = max(0, int(quest_tasks or 0))
 
         # Nothing happened (e.g. an empty batch in advanced scheduling and no
         # balance to refresh) — don't pollute the timeline with a no-op run.
-        if pc == 0 and mobile == 0 and cards == 0 and balance is None:
+        if (
+            pc == 0
+            and mobile == 0
+            and cards == 0
+            and earn == 0
+            and quests == 0
+            and (balance is None)
+        ):
             return self.get_stats()
 
         stats = self.get_stats()
         session_estimate = (
             pc * POINTS_PER_SEARCH
             + mobile * POINTS_PER_SEARCH
-            + cards * POINTS_PER_CARD
+            + (cards + earn + quests) * POINTS_PER_CARD
         )
 
         lifetime = stats["lifetime"]
         lifetime["pc_searches"] += pc
         lifetime["mobile_searches"] += mobile
         lifetime["daily_cards"] += cards
+        lifetime["earn_cards"] = lifetime.get("earn_cards", 0) + earn
+        lifetime["quest_tasks"] = lifetime.get("quest_tasks", 0) + quests
         lifetime["runs"] += 1
         lifetime["points_estimate"] += session_estimate
 
@@ -407,18 +430,24 @@ class StatsManager:
             "pc_searches": pc,
             "mobile_searches": mobile,
             "daily_cards": cards,
+            "earn_cards": earn,
+            "quest_tasks": quests,
             "points_estimate": session_estimate,
             "points_delta": points_delta,
         }
 
-        # Fold this run into today's per-day aggregate.
+        # Fold this run into today's per-day aggregate. Pre-existing day
+        # buckets from older stats.json files lack the earn/quests keys, so
+        # those are folded in .get-safely.
         today = now_iso[:10]
         bucket = stats["daily"].setdefault(
-            today, {"pc": 0, "mobile": 0, "cards": 0, "runs": 0}
+            today, {"pc": 0, "mobile": 0, "cards": 0, "earn": 0, "quests": 0, "runs": 0}
         )
         bucket["pc"] += pc
         bucket["mobile"] += mobile
         bucket["cards"] += cards
+        bucket["earn"] = bucket.get("earn", 0) + earn
+        bucket["quests"] = bucket.get("quests", 0) + quests
         bucket["runs"] += 1
         stats["daily"] = self._trim_daily(stats["daily"])
 

--- a/src/stats/manager.py
+++ b/src/stats/manager.py
@@ -33,7 +33,9 @@ POINTS_PER_CARD = 10
 _DAILY_KEEP = 90
 
 # JS executed on rewards.bing.com (or a Bing SERP) to read the user's current
-# available-points balance. Tries a series of known selectors and returns an
+# available-points balance. Works on both the legacy mee-rewards-* dashboard
+# (DOM selectors) and the new Next.js dashboard (RSC payload in window.__next_f).
+# Tries a series of known selectors and returns an
 # object {value, via, candidates}. `value` is the first plausible integer found
 # (thousand separators stripped) or null; `candidates` is a small sample of
 # what each selector matched, logged when value is null so the real (locale-
@@ -88,6 +90,39 @@ return (function () {
       }
     }
   }
+  // New (Next.js) dashboard: none of the legacy mee-rewards-* nodes exist. The
+  // available-points balance is streamed into the RSC payload (window.__next_f)
+  // as "availablePoints":<int> / "balance":<int> (the ProfileUpdate value), not
+  // rendered into any stable DOM node. Read it from there. On the legacy
+  // dashboard or a Bing SERP __next_f is absent, so this block is a no-op.
+  try {
+    if (window.__next_f) {
+      var parts = [];
+      for (var k = 0; k < window.__next_f.length; k++) {
+        var e = window.__next_f[k];
+        if (Array.isArray(e)) { if (typeof e[1] === 'string') parts.push(e[1]); }
+        else if (typeof e === 'string') { parts.push(e); }
+      }
+      var blob = parts.join('');
+      // Prefer availablePoints; fall back to balance. Take the last match so a
+      // client-refreshed value wins over an earlier server-rendered one.
+      var keys = ['availablePoints', 'balance'];
+      for (var ki = 0; ki < keys.length; ki++) {
+        var re = new RegExp('"' + keys[ki] + '"\\s*:\\s*(\\d+)', 'g');
+        var m, last = null;
+        while ((m = re.exec(blob)) !== null) { last = parseInt(m[1], 10); }
+        if (last != null && isFinite(last) && last >= 0) {
+          if (candidates.length < 14) {
+            candidates.push('__next_f.' + keys[ki] + ' => [' + last + ']');
+          }
+          return {
+            value: last, via: 'new-dashboard:' + keys[ki], candidates: candidates,
+            url: location.href, title: document.title
+          };
+        }
+      }
+    }
+  } catch (eNext) { /* fall through to null */ }
   return {
     value: null, via: null, candidates: candidates,
     url: location.href, title: document.title

--- a/src/stats/manager.py
+++ b/src/stats/manager.py
@@ -67,6 +67,10 @@ return (function () {
     'mee-rewards-user-status-banner-balance mee-rewards-counter-animation span',
     'mee-rewards-user-status-banner-balance .pointsValue',
     '#balanceToolTipDiv .pointsValue',
+    // New (Next.js) dashboard: the "Points disponibles" card links to /redeem
+    // and shows the balance in a .text-pageHeader node. Scoped to that card so
+    // we don't pick the member-name header (same class, different anchor).
+    'a[href="/redeem"] .text-pageHeader',
     '#fly_id_rc', '#id_rc'
   ];
   var candidates = [];


### PR DESCRIPTION
## Summary

Microsoft is rolling out a redesigned **React/Next.js Rewards dashboard** that
replaces the legacy Angular `mee-rewards-*` UI. On a migrated account the old
selectors match nothing, so the app silently did nothing: no Daily Set, no
points balance. This PR adds full support for the new dashboard **alongside**
the legacy one, selectable per account.

## Background

The new dashboard (`rewards.bing.com/dashboard` + `/earn`) is a Next.js app:
- Its Tailwind class names are hashed/obfuscated, so scraping markup by class is
  fragile.
- Activity data is streamed as an RSC payload (`window.__next_f`) that carries
  each offer's `destination`, `isCompleted`, `points` and `title` — but it is
  **drained after hydration**, so a runtime read must fall back to the DOM.
- Crucially, a **real pointer click** on a card (which opens its search in a new
  tab) is what credits the offer server-side; a bare `driver.get(destination)`
  does **not** credit.

## What's included

### Per-account dashboard selection
- New `dashboard_variant` setting per account: `auto` (default) | `legacy` |
  `new`, persisted in `meta.json`. Fully backward compatible — existing accounts
  resolve to `auto` and are unaffected.
- `auto` detects at runtime which dashboard rendered, so migrated accounts work
  with zero configuration.
- Exposed through the API and a new dropdown in the account settings UI.

### Points balance
- Reads the balance from the new dashboard (DOM + embedded JSON), with the
  legacy path preserved. Multi-source, multi-URL retry with a diagnostic log
  line on failure.

### Daily Set (new dashboard)
- New `NewDashboardDailySet` handler: reads today's activities from the RSC JSON
  (polling until the streamed chunk set stabilizes, since a partial snapshot
  can miss cards or even hold only another, already-completed day) and
  cross-checks against the rendered `#dailyset` DOM — the DOM is ground truth
  for which cards are today's, the JSON for completion flags.
- Completes each incomplete activity with a **real click** (new-tab dwell +
  close + return), which credits the offer — works even in headless / "Hide
  browser" mode.
- **Honest completion check**: re-reads the dashboard to confirm activities
  actually flipped to complete before marking the day done, so a headless run
  that fails to credit is reported instead of falsely succeeding.

### /earn "more activities"
- Clicks the incomplete point-earning cards on `/earn` (the `+N` badge cards),
  mirroring the legacy "More Activities" section.

### /earn quests (punchcards)
- Discovers quests via their `/earn/quest/<id>` links, opens each incomplete
  one, and clicks the currently **actionable** tasks (real click to credit).
- Only quests that **award points** are automated (identified by a `+N`
  badge); promo/partner quests without a points badge are skipped. Points
  and progress are read from their own badge/counter elements, not the
  card's concatenated text (adjacent nodes would otherwise merge).
- Punchcard tasks are time-gated — typically one unlocks per ~24h — so a run
  completes only what's unlocked; locked (`aria-disabled`/`data-disabled`) and
  completed tasks are skipped. Full completion spans several daily runs.

### Claim pending points
- New-dashboard points sit in a **pending** state and must be *claimed* to
  count toward the balance (they expire ~1 month after being earned). After
  the Daily Set, the handler opens the dashboard "ready to claim" tile and
  clicks the flyout's primary button to claim them. Matched language-
  independently (coins-icon asset, `statusDanger` / `bg-flyout` /
  `bgCtrlBrandRest` design tokens, `slot` attributes) — never localized text.

### Per-account statistics
- Runs are recorded per category: verified Daily Set completions, /earn cards
  opened and quest tasks opened each have their own lifetime counters, session
  breakdown and chart segments (with legend) in the stats dashboard. Backward
  compatible with existing stats.json files.

## Design notes
- **Language-independent selectors.** The app UI is English but a user's Rewards
  page may be localized. All new selectors rely on stable signals only — URLs
  (`/earn/quest/`, `bing.com/search`), design tokens (`statusSuccess`,
  `rewardsTableAltBg`, `text-globalBody2Strong`), ARIA attributes
  (`aria-disabled`) and numeric badges (`+N`, `N/M`) — never on localized text.
- **No behavior change for legacy accounts.** The legacy path is untouched;
  the new code runs only when the account resolves to the new dashboard.

## Testing
- `black`, `flake8`, `mypy` clean (pre-commit hooks pass).
- Python compiles; the embedded JS extractors validated with `node --check`.
- Manually verified on a real migrated account: balance reads correctly, Daily
  Set credits (including in "Hide browser" mode), and `/earn` activities and
  quest tasks credit (quest punchcards verified end-to-end on a live account).

## Known limitations / follow-ups
- **Headless crediting**: Rewards sometimes declines to credit a fully headless
  session; the handler reports this honestly rather than marking the day done,
  so a later visible run can retry.
- Out of scope for now (deferred): `/earn` "Explore on Bing".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-account “Rewards dashboard” selection (auto/legacy/new) for scheduled runs and saved with each account’s schedule.
  * Expanded redesigned dashboard automation to run daily sets and related earn/quest flows with stronger completion verification.
* **Bug Fixes**
  * Improved balance scraping by trying multiple dashboard entry points and showing clearer diagnostics/warnings when balances can’t be retrieved.
* **UI/Analytics**
  * Added “Earn cards” and “Quest tasks” to lifetime and recent activity dashboards/charts.
* **Chores**
  * Reduced headless startup window flash on Edge/Chromium.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


