### PR TITLE
feat: language-aware LLM search-term generation (opt-in, bring-your-own-key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ For common issues and solutions, see the [Troubleshooting](USER_GUIDE.md#trouble
 - [x] Statistics dashboard (points tracking, session summaries)
 - [x] Daily "Claim" actions
 - [x] The New Dashboard Support
+- [x] AI-generated search terms in your language (bring-your-own-key LLM)
 - [ ] Simulated human typos during search input
 - [ ] Region-specific search query datasets (US, UK, CA, AU, IN, etc.)
 - [ ] Browser choice (Chrome, Firefox support in addition to Edge)

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -163,6 +163,19 @@ This toggle controls whether you can see Microsoft Edge while searches are happe
 - Less distracting if you're working on something else
 - Slightly faster performance since it doesn't have to render the browser window what will save system resources (RAM/CPU)
 
+### AI-generated search terms (LLM)
+
+By default, AutoRewarder draws its searches from a large built-in list of English queries. If you'd prefer searches that look natural in **your own language**, enable **"Generate search terms with AI (LLM)"** in the Settings window and provide your own LLM API key (bring-your-own-key).
+
+- **Provider & model:** Choose OpenAI, Anthropic, or Google Gemini, and optionally a specific model (leave blank to use a sensible default for that provider).
+- **API key:** Paste a key from your chosen provider. It is stored locally in your `settings.json` (plain text) and is only sent to that provider to request queries — no personal data is shared.
+- **Language:** Leave **`auto`** to follow the language of the computer running AutoRewarder (detected automatically), or type a locale such as `fr-FR`, `it-IT`, or `en-US` to force one.
+
+On each run, AutoRewarder asks the provider for a fresh batch of queries in your language. If generation fails for any reason — no key, an invalid key, an exceeded quota, or no internet — it silently falls back to the built-in list, so your run always completes.
+
+> [!NOTE]
+> Using an LLM provider may incur costs on your provider account, depending on their pricing. Query generation uses very few tokens per run.
+
 ### Autostart & Daily Run Time
 When enabled, AutoRewarder uses your operating system's native task scheduler (Windows Task Scheduler or Linux systemd) to launch headless runs in the background.
 

--- a/gui/index.html
+++ b/gui/index.html
@@ -224,6 +224,49 @@
         </section>
 
         <section class="settings-group">
+          <div class="settings-group-title">Search terms</div>
+          <label class="settings-row">
+            <div class="settings-row-text">
+              <div class="settings-row-label">Generate search terms with AI (LLM)</div>
+              <div class="settings-row-hint">Use your own LLM API key to generate fresh queries in your language on each run. Falls back to the built-in list if generation fails.</div>
+            </div>
+            <span class="toggle-compact">
+              <input type="checkbox" id="llmToggle">
+              <span class="toggle-pill"></span>
+            </span>
+          </label>
+
+          <div id="llm_fields" class="llm-fields">
+            <div class="form-grid-2">
+              <div class="form-field">
+                <label for="llmProvider">Provider</label>
+                <select id="llmProvider">
+                  <option value="openai">OpenAI</option>
+                  <option value="anthropic">Anthropic</option>
+                  <option value="gemini">Google Gemini</option>
+                </select>
+              </div>
+              <div class="form-field">
+                <label for="llmModel">Model</label>
+                <input type="text" id="llmModel" placeholder="Default for provider" autocomplete="off" spellcheck="false">
+              </div>
+            </div>
+            <div class="form-grid-2">
+              <div class="form-field">
+                <label for="llmApiKey">API key</label>
+                <input type="password" id="llmApiKey" placeholder="Your own API key" autocomplete="off" spellcheck="false">
+              </div>
+              <div class="form-field">
+                <label for="llmLocale">Language</label>
+                <input type="text" id="llmLocale" placeholder="auto" autocomplete="off" spellcheck="false">
+              </div>
+            </div>
+            <p class="form-hint" id="llm_locale_hint">Leave "auto" to follow your system language, or enter a locale like fr-FR.</p>
+            <p class="form-hint">Your API key is stored locally in settings.json (plain text). Requests only send a prompt asking for queries — no personal data.</p>
+          </div>
+        </section>
+
+        <section class="settings-group">
           <div class="settings-group-title">Scheduled runs</div>
           <p class="settings-group-hint">
             One schedule per account. Each run fires at a random minute inside its window for a natural look.

--- a/gui/script.js
+++ b/gui/script.js
@@ -677,7 +677,8 @@ function open_settings_modal() {
     pywebview.api.get_all_schedules(),
     pywebview.api.get_launch_on_startup(),
     pywebview.api.get_close_to_tray(),
-  ]).then(([schedules, startup, closeToTray]) => {
+    pywebview.api.get_llm_config(),
+  ]).then(([schedules, startup, closeToTray, llmConfig]) => {
     render_schedule_cards(schedules || []);
 
     // Start-with-Windows toggle — disable row on unsupported OS.
@@ -700,6 +701,26 @@ function open_settings_modal() {
     if (trayToggle) {
       trayToggle.checked = closeToTray !== false;
     }
+
+    // LLM search-term generation.
+    const cfg = llmConfig || {};
+    const llmToggle = document.getElementById('llmToggle');
+    const providerSel = document.getElementById('llmProvider');
+    const modelInput = document.getElementById('llmModel');
+    const keyInput = document.getElementById('llmApiKey');
+    const localeInput = document.getElementById('llmLocale');
+    const localeHint = document.getElementById('llm_locale_hint');
+    if (llmToggle) llmToggle.checked = Boolean(cfg.use_llm_queries);
+    if (providerSel && cfg.llm_provider) providerSel.value = cfg.llm_provider;
+    if (modelInput) modelInput.value = cfg.llm_model || '';
+    if (keyInput) keyInput.value = cfg.llm_api_key || '';
+    if (localeInput) localeInput.value = cfg.search_locale || 'auto';
+    if (localeHint) {
+      const eff = cfg.effective_locale || 'en-US';
+      localeHint.textContent =
+        `Detected language: ${eff}. Leave "auto" to follow your system, or enter a locale like fr-FR.`;
+    }
+    apply_llm_field_state();
   }).catch(err => {
     console.error('Failed to load settings:', err);
     show_toast('Could not load settings.', 'error');
@@ -711,6 +732,14 @@ function open_settings_modal() {
 function close_settings_modal() {
   const backdrop = document.getElementById('settings_modal');
   if (backdrop) backdrop.hidden = true;
+}
+
+// Dim + disable the LLM config fields when the feature is toggled off.
+function apply_llm_field_state() {
+  const toggle = document.getElementById('llmToggle');
+  const fields = document.getElementById('llm_fields');
+  if (!fields) return;
+  fields.classList.toggle('dim', !(toggle && toggle.checked));
 }
 
 function render_schedule_cards(schedules) {
@@ -1040,6 +1069,16 @@ async function save_settings() {
       pywebview.api.set_dashboard_variant(p.id, p.dashboardVariant)
     ));
 
+    // Persist LLM search-term config (independent of the schedule slicing).
+    const llmToggleEl = document.getElementById('llmToggle');
+    await pywebview.api.set_llm_config(
+      Boolean(llmToggleEl && llmToggleEl.checked),
+      document.getElementById('llmProvider').value,
+      document.getElementById('llmModel').value,
+      document.getElementById('llmApiKey').value,
+      document.getElementById('llmLocale').value
+    );
+
     const scheduleCalls = payloads.map(p =>
       pywebview.api.set_schedule(p.id, p.payload)
     );
@@ -1235,6 +1274,10 @@ document.addEventListener('DOMContentLoaded', function() {
   if (settingsCancel) settingsCancel.addEventListener('click', close_settings_modal);
   const settingsSave = document.getElementById('settingsSave');
   if (settingsSave) settingsSave.addEventListener('click', save_settings);
+
+  // LLM feature toggle dims/undims its config fields live.
+  const llmToggle = document.getElementById('llmToggle');
+  if (llmToggle) llmToggle.addEventListener('change', apply_llm_field_state);
   const settingsModal = document.getElementById('settings_modal');
   if (settingsModal) {
     settingsModal.addEventListener('click', (e) => {
@@ -1282,6 +1325,16 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 window.addEventListener('pywebviewready', function() {
+  // Report the OS/browser language so LLM query generation can default to it.
+  try {
+    if (navigator && navigator.language &&
+        typeof pywebview.api.set_detected_locale === 'function') {
+      pywebview.api.set_detected_locale(navigator.language);
+    }
+  } catch (e) {
+    console.error('Failed to report locale:', e);
+  }
+
   pywebview.api.get_settings().then(function(settings) {
     const toggle = document.getElementById('hideBrowserToggle');
     if (toggle) toggle.checked = Boolean(settings.hide_browser);

--- a/gui/styles.css
+++ b/gui/styles.css
@@ -1427,6 +1427,8 @@ input[type="number"]:focus {
 
 .form-field input[type="time"],
 .form-field input[type="number"],
+.form-field input[type="text"],
+.form-field input[type="password"],
 .form-field select {
   width: 100%;
   padding: 8px 10px;
@@ -1463,6 +1465,25 @@ input[type="number"]:focus {
   font-size: 11.5px;
   color: var(--text-dim);
   line-height: 1.45;
+}
+
+/* LLM search-term generation fields (Settings modal) */
+
+.llm-fields {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: opacity 0.15s;
+}
+
+.llm-fields.dim {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.llm-fields .form-hint {
+  margin: 2px 0 0 0;
 }
 
 .row-disabled {

--- a/src/accounts/settings.py
+++ b/src/accounts/settings.py
@@ -100,6 +100,19 @@ class GlobalSettingsManager:
             # Default query counts.
             "queries_pc": 30,
             "queries_mobile": 20,
+            # LLM-generated search terms (bring-your-own-key). When enabled and
+            # a key is present, each phase asks the chosen provider for fresh
+            # queries in the user's language; any failure falls back to the
+            # static assets/queries.json. The key is stored in plain text here,
+            # consistent with the rest of settings.json.
+            "use_llm_queries": False,
+            "llm_provider": "openai",  # openai | anthropic | gemini
+            "llm_model": "",  # blank = provider default
+            "llm_api_key": "",
+            # Language of generated queries. "auto" resolves from
+            # detected_locale (navigator.language) or OS detection.
+            "search_locale": "auto",
+            "detected_locale": "",  # filled by the GUI from navigator.language
         }
 
         if APP_DIR and not os.path.exists(APP_DIR):
@@ -178,3 +191,57 @@ class GlobalSettingsManager:
         settings = self.get_settings()
         settings["queries_mobile"] = max(0, min(99, int(count)))
         self.save_settings(settings)
+
+    # ------------------------------------------------------------------
+    # LLM-generated search terms + locale
+    # ------------------------------------------------------------------
+
+    # Kept in sync with search.llm.DEFAULT_MODELS.
+    _LLM_PROVIDERS = ("openai", "anthropic", "gemini")
+
+    def get_llm_config(self):
+        """Return the LLM query-generation config from settings."""
+        s = self.get_settings()
+        return {
+            "use_llm_queries": bool(s.get("use_llm_queries", False)),
+            "llm_provider": s.get("llm_provider", "openai"),
+            "llm_model": s.get("llm_model", ""),
+            "llm_api_key": s.get("llm_api_key", ""),
+            "search_locale": s.get("search_locale", "auto"),
+            "detected_locale": s.get("detected_locale", ""),
+        }
+
+    def set_llm_config(
+        self, use_llm_queries, provider, model, api_key, search_locale="auto"
+    ):
+        """Persist the LLM query-generation config.
+
+        Unknown providers fall back to "openai"; an empty locale becomes
+        "auto". The API key is stored as-is (plain text) alongside the other
+        settings.
+        """
+        provider = str(provider or "openai").strip().lower()
+        if provider not in self._LLM_PROVIDERS:
+            provider = "openai"
+
+        locale = str(search_locale or "").strip() or "auto"
+
+        settings = self.get_settings()
+        settings["use_llm_queries"] = bool(use_llm_queries)
+        settings["llm_provider"] = provider
+        settings["llm_model"] = str(model or "").strip()
+        settings["llm_api_key"] = str(api_key or "").strip()
+        settings["search_locale"] = locale
+        self.save_settings(settings)
+
+    def set_detected_locale(self, locale):
+        """Persist the locale reported by the GUI (navigator.language)."""
+        settings = self.get_settings()
+        settings["detected_locale"] = str(locale or "").strip()
+        self.save_settings(settings)
+
+    def get_effective_locale(self):
+        """Return the locale that query generation will actually use."""
+        from ..search.locale import resolve_search_locale
+
+        return resolve_search_locale(self.get_settings())

--- a/src/accounts/settings.py
+++ b/src/accounts/settings.py
@@ -196,9 +196,6 @@ class GlobalSettingsManager:
     # LLM-generated search terms + locale
     # ------------------------------------------------------------------
 
-    # Kept in sync with search.llm.DEFAULT_MODELS.
-    _LLM_PROVIDERS = ("openai", "anthropic", "gemini")
-
     def get_llm_config(self):
         """Return the LLM query-generation config from settings."""
         s = self.get_settings()
@@ -220,8 +217,10 @@ class GlobalSettingsManager:
         "auto". The API key is stored as-is (plain text) alongside the other
         settings.
         """
+        from ..search.llm import SUPPORTED_PROVIDERS
+
         provider = str(provider or "openai").strip().lower()
-        if provider not in self._LLM_PROVIDERS:
+        if provider not in SUPPORTED_PROVIDERS:
             provider = "openai"
 
         locale = str(search_locale or "").strip() or "auto"

--- a/src/api.py
+++ b/src/api.py
@@ -35,7 +35,7 @@ from .accounts import (
     GlobalSettingsManager,
 )
 from .emulator import DriverManager, HumanBehavior, edge_policy
-from .search import HistoryManager, SearchEngine
+from .search import HistoryManager, SearchEngine, llm, resolve_search_locale
 from .dailytasks import DailySet
 from .stats import (
     StatsManager,
@@ -491,6 +491,56 @@ class AutoRewarderAPI:
             return True
         except Exception as e:
             self.log(f"[WARNING] Failed to save search counts: {e}")
+            return False
+
+    # ------------------------------------------------------------------
+    # Exposed to JS: LLM-generated search terms + locale
+    # ------------------------------------------------------------------
+
+    def get_llm_config(self):
+        """
+        Return the LLM query-generation config plus the effective locale.
+
+        Returns:
+            dict: use_llm_queries, llm_provider, llm_model, llm_api_key,
+            search_locale, detected_locale, effective_locale.
+        """
+        cfg = self.global_settings.get_llm_config()
+        cfg["effective_locale"] = self.global_settings.get_effective_locale()
+        return cfg
+
+    def set_llm_config(
+        self, use_llm_queries, provider, model, api_key, search_locale="auto"
+    ):
+        """
+        Persist the LLM query-generation config from the Settings modal.
+
+        Returns:
+            bool: True on success, False otherwise.
+        """
+        try:
+            self.global_settings.set_llm_config(
+                use_llm_queries, provider, model, api_key, search_locale
+            )
+            state = "ON" if use_llm_queries else "OFF"
+            self.log(f"LLM query generation: {state} ({provider}).")
+            return True
+        except Exception as e:
+            self.log(f"[WARNING] Failed to save LLM config: {e}")
+            return False
+
+    def set_detected_locale(self, locale):
+        """
+        Store the locale the GUI read from navigator.language.
+
+        Returns:
+            bool: True on success, False otherwise.
+        """
+        try:
+            self.global_settings.set_detected_locale(locale)
+            return True
+        except Exception as e:
+            self.log(f"[WARNING] Failed to save detected locale: {e}")
             return False
 
     # ------------------------------------------------------------------
@@ -2350,6 +2400,76 @@ class AutoRewarderAPI:
             self._driver = None
             time.sleep(0.5)
 
+    def _build_queries(self, count):
+        """
+        Build the list of queries for a phase.
+
+        When LLM generation is enabled and an API key is set, ask the chosen
+        provider for `count` fresh queries in the user's language. Any failure
+        (no key, invalid key, quota, offline, malformed answer) or a shortfall
+        is transparently topped up / replaced with a random sample from the
+        static assets/queries.json, so the daily search target is still met and
+        the run never depends on the network.
+
+        Args:
+            count (int): how many queries to produce.
+
+        Returns:
+            list: up to `count` query strings (empty only if the static file is
+            missing).
+        """
+        if count <= 0:
+            return []
+
+        queries = []
+        cfg = self.global_settings.get_llm_config()
+        if cfg["use_llm_queries"]:
+            if cfg["llm_api_key"]:
+                locale = resolve_search_locale(
+                    self.global_settings.get_settings(), self.log
+                )
+                self.log(
+                    f"Generating {count} queries via LLM "
+                    f"({cfg['llm_provider']}, {locale})…"
+                )
+                queries = llm.generate_queries(
+                    count,
+                    locale,
+                    provider=cfg["llm_provider"],
+                    model=cfg["llm_model"],
+                    api_key=cfg["llm_api_key"],
+                    logger=self.log,
+                )
+                if not queries:
+                    self.log(
+                        "[WARNING] LLM generation failed — "
+                        "falling back to static queries."
+                    )
+            else:
+                self.log(
+                    "[WARNING] LLM enabled but no API key set — "
+                    "using static queries."
+                )
+
+        if len(queries) >= count:
+            return queries[:count]
+
+        # Top up from the static file, skipping any query the LLM already
+        # produced. Request extra headroom so de-dup can't leave us short.
+        static = self.search_engine.load_queries_from_json(
+            JSON_FILE_PATH, num_needed=count + len(queries)
+        )
+        if not queries:
+            return static
+
+        seen = set(queries)
+        extra = [q for q in static if q not in seen][: count - len(queries)]
+        self.log(
+            f"LLM returned {len(queries)}/{count} queries — "
+            f"topped up with {len(extra)} static queries."
+        )
+        return queries + extra
+
     def _run_phase(self, mobile, count, do_daily_set):
         """
         Open a driver for a single phase (PC or Mobile), do `count` searches,
@@ -2365,9 +2485,7 @@ class AutoRewarderAPI:
             f"=== {label} phase — {count} {'queries' if count != 1 else 'query'} ==="
         )
 
-        queries_to_search = self.search_engine.load_queries_from_json(
-            JSON_FILE_PATH, num_needed=count
-        )
+        queries_to_search = self._build_queries(count)
         if not queries_to_search:
             self.log(f"[WARNING] {label}: no queries available. Skipping phase.")
             if self.history is not None:

--- a/src/search/__init__.py
+++ b/src/search/__init__.py
@@ -1,4 +1,6 @@
+from . import llm
 from .engine import SearchEngine
 from .history import HistoryManager
+from .locale import resolve_search_locale
 
-__all__ = ["SearchEngine", "HistoryManager"]
+__all__ = ["SearchEngine", "HistoryManager", "llm", "resolve_search_locale"]

--- a/src/search/llm.py
+++ b/src/search/llm.py
@@ -81,6 +81,7 @@ def _call_openai(prompt, model, api_key, max_tokens, logger):
             "model": model,
             "messages": [{"role": "user", "content": prompt}],
             "temperature": 1.0,
+            "max_completion_tokens": max_tokens,
         },
         timeout=_TIMEOUT,
     )

--- a/src/search/llm.py
+++ b/src/search/llm.py
@@ -1,0 +1,236 @@
+"""LLM-backed search-query generation (bring-your-own-key).
+
+Given a target count and a locale, ask a cloud LLM to produce fresh, natural
+web-search queries written in the user's language. The app ships no AI SDK;
+every call goes over plain HTTP with the ``requests`` library already listed
+in ``requirements.txt``.
+
+Robustness is the priority: this is a set-and-forget / scheduled tool, so
+``generate_queries`` **never raises**. Every failure path — missing or invalid
+key, quota / rate-limit, offline, timeout, malformed response — returns an
+empty list and logs the cause, letting the caller fall back to the static
+query file.
+"""
+
+import json
+
+import requests
+
+from .locale import language_name
+
+# Provider -> default model used when the user leaves the model field blank.
+# The model stays editable in the UI so users can track newer models without a
+# code change.
+DEFAULT_MODELS = {
+    "openai": "gpt-5.4-nano",
+    "anthropic": "claude-haiku-4-5",
+    "gemini": "gemini-3.1-flash-lite",
+}
+
+SUPPORTED_PROVIDERS = tuple(DEFAULT_MODELS.keys())
+
+_TIMEOUT = 30  # seconds, per request
+_ANTHROPIC_VERSION = "2023-06-01"
+
+
+def _max_tokens(count):
+    """Rough output-token budget for `count` short JSON-array queries."""
+    return min(8192, 512 + count * 30)
+
+
+def _build_prompt(count, loc):
+    """Phrase the generation instruction in the user's language."""
+    lang = language_name(loc)
+    return (
+        f"Generate {count} realistic, varied web search queries that a typical "
+        f"person would type into a search engine. Write them in {lang} "
+        f"(locale {loc}). Mix everyday topics: news, weather, recipes, sports, "
+        f"shopping, how-to, entertainment, technology, health and local "
+        f"interests. Keep each query short and natural (about 2 to 6 words), "
+        f"with no numbering, no quotes and no explanations. "
+        f"Return ONLY a JSON array of {count} distinct strings."
+    )
+
+
+def _log_http_error(logger, provider, resp):
+    """Translate a non-2xx response into a clear, actionable log line."""
+    if not logger:
+        return
+    status = resp.status_code
+    if status in (401, 403):
+        reason = "invalid or unauthorized API key"
+    elif status == 429:
+        reason = "rate limit or quota exceeded"
+    elif status == 402:
+        reason = "billing / quota exhausted"
+    else:
+        reason = f"HTTP {status}"
+    snippet = (resp.text or "").replace("\n", " ")[:200]
+    logger(f"[WARNING] LLM ({provider}) request failed: {reason}. {snippet}")
+
+
+def _call_openai(prompt, model, api_key, max_tokens, logger):
+    """OpenAI Chat Completions. Returns the model's text answer or ''."""
+    resp = requests.post(
+        "https://api.openai.com/v1/chat/completions",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 1.0,
+        },
+        timeout=_TIMEOUT,
+    )
+    if resp.status_code != 200:
+        _log_http_error(logger, "openai", resp)
+        return ""
+    data = resp.json()
+    return data["choices"][0]["message"]["content"] or ""
+
+
+def _call_anthropic(prompt, model, api_key, max_tokens, logger):
+    """Anthropic Messages API. Returns the model's text answer or ''."""
+    resp = requests.post(
+        "https://api.anthropic.com/v1/messages",
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": _ANTHROPIC_VERSION,
+            "Content-Type": "application/json",
+        },
+        json={
+            "model": model,
+            "max_tokens": max_tokens,
+            "temperature": 1.0,
+            "messages": [{"role": "user", "content": prompt}],
+        },
+        timeout=_TIMEOUT,
+    )
+    if resp.status_code != 200:
+        _log_http_error(logger, "anthropic", resp)
+        return ""
+    data = resp.json()
+    blocks = data.get("content", [])
+    return "".join(b.get("text", "") for b in blocks if isinstance(b, dict))
+
+
+def _call_gemini(prompt, model, api_key, max_tokens, logger):
+    """Google Gemini generateContent. Returns the model's text answer or ''."""
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{model}:generateContent"
+    )
+    resp = requests.post(
+        url,
+        headers={"Content-Type": "application/json"},
+        params={"key": api_key},
+        json={
+            "contents": [{"parts": [{"text": prompt}]}],
+            "generationConfig": {
+                "temperature": 1.0,
+                "maxOutputTokens": max_tokens,
+            },
+        },
+        timeout=_TIMEOUT,
+    )
+    if resp.status_code != 200:
+        _log_http_error(logger, "gemini", resp)
+        return ""
+    data = resp.json()
+    candidates = data.get("candidates") or [{}]
+    parts = candidates[0].get("content", {}).get("parts", [])
+    return "".join(p.get("text", "") for p in parts if isinstance(p, dict))
+
+
+_DISPATCH = {
+    "openai": _call_openai,
+    "anthropic": _call_anthropic,
+    "gemini": _call_gemini,
+}
+
+
+def _extract_queries(text, count):
+    """Parse a JSON array of strings out of the model's text answer.
+
+    Tolerates code fences and surrounding prose by locating the outermost
+    ``[...]`` span. Returns a de-duplicated, order-preserving list capped at
+    `count`.
+    """
+    if not text:
+        return []
+
+    start = text.find("[")
+    end = text.rfind("]")
+    if start == -1 or end == -1 or end <= start:
+        return []
+
+    end += 1
+    try:
+        data = json.loads(text[start:end])
+    except (ValueError, TypeError):
+        return []
+
+    if not isinstance(data, list):
+        return []
+
+    out = []
+    for item in data:
+        if isinstance(item, str):
+            query = item.strip().strip('"').strip()
+            if query:
+                out.append(query)
+
+    # De-duplicate while preserving order, then cap at the requested count.
+    return list(dict.fromkeys(out))[:count]
+
+
+def generate_queries(
+    count, locale, provider="openai", model="", api_key="", logger=None
+):
+    """Generate up to `count` search queries in `locale`'s language via an LLM.
+
+    Args:
+        count (int): number of queries to request.
+        locale (str): BCP-47 locale (e.g. ``"fr-FR"``) driving the language.
+        provider (str): one of ``openai`` / ``anthropic`` / ``gemini``.
+        model (str): model id; falls back to the provider default when blank.
+        api_key (str): the user's own API key.
+        logger (callable, optional): logging function.
+
+    Returns:
+        list[str]: query strings, or ``[]`` on any failure. Never raises.
+    """
+    try:
+        count = int(count)
+    except (TypeError, ValueError):
+        return []
+    if count <= 0 or not api_key:
+        return []
+
+    provider = (provider or "openai").strip().lower()
+    caller = _DISPATCH.get(provider)
+    if caller is None:
+        if logger:
+            logger(f"[WARNING] LLM: unsupported provider '{provider}'.")
+        return []
+
+    model = (model or "").strip() or DEFAULT_MODELS[provider]
+    prompt = _build_prompt(count, locale)
+
+    try:
+        text = caller(prompt, model, api_key, _max_tokens(count), logger)
+    except requests.RequestException as e:
+        if logger:
+            logger(f"[WARNING] LLM ({provider}) network error: {e}")
+        return []
+    except (KeyError, IndexError, ValueError, TypeError) as e:
+        if logger:
+            logger(f"[WARNING] LLM ({provider}) unexpected response: {e}")
+        return []
+
+    queries = _extract_queries(text, count)
+    if not queries and logger:
+        logger(f"[WARNING] LLM ({provider}) returned no usable queries.")
+    return queries

--- a/src/search/locale.py
+++ b/src/search/locale.py
@@ -1,0 +1,171 @@
+"""Locale detection and language resolution for search-query generation.
+
+Decides which language the auto-generated (LLM) search queries should be
+written in.
+
+In the desktop GUI the browser reports the OS locale via
+``navigator.language``; that value is persisted to settings and preferred
+here. In headless/CLI runs there is no browser, so we fall back to the Python
+``locale`` module, the ``LANG`` family of environment variables, and (on
+Windows) the Win32 user-default locale.
+"""
+
+import locale as _locale
+import os
+
+# Primary language subtag -> human-readable English name, used only to phrase
+# the generation prompt ("...in French."). We look at the language part only,
+# so "fr-FR" and "fr-CA" both resolve to "French".
+_LANGUAGE_NAMES = {
+    "ar": "Arabic",
+    "cs": "Czech",
+    "da": "Danish",
+    "de": "German",
+    "el": "Greek",
+    "en": "English",
+    "es": "Spanish",
+    "fi": "Finnish",
+    "fr": "French",
+    "he": "Hebrew",
+    "hi": "Hindi",
+    "hu": "Hungarian",
+    "id": "Indonesian",
+    "it": "Italian",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "nl": "Dutch",
+    "no": "Norwegian",
+    "pl": "Polish",
+    "pt": "Portuguese",
+    "ro": "Romanian",
+    "ru": "Russian",
+    "sk": "Slovak",
+    "sv": "Swedish",
+    "th": "Thai",
+    "tr": "Turkish",
+    "uk": "Ukrainian",
+    "vi": "Vietnamese",
+    "zh": "Chinese",
+}
+
+DEFAULT_LOCALE = "en-US"
+
+
+def _normalize(tag):
+    """Normalize a raw locale string to a BCP-47 ``ll-CC`` (or ``ll``) form.
+
+    Accepts values like ``fr_FR.UTF-8``, ``fr-FR``, ``fr``, ``C`` or ``""``
+    and returns e.g. ``fr-FR`` / ``fr``, or ``""`` when nothing usable is left.
+    """
+    if not tag:
+        return ""
+
+    tag = str(tag).strip()
+    # Drop encoding suffix (fr_FR.UTF-8 -> fr_FR) and unify separators.
+    tag = tag.split(".")[0].split("@")[0].replace("_", "-")
+
+    if not tag or tag.lower() in ("c", "posix", "auto"):
+        return ""
+
+    parts = tag.split("-")
+    lang = parts[0].lower()
+    if not lang.isalpha():
+        return ""
+
+    if len(parts) > 1 and parts[1]:
+        return f"{lang}-{parts[1].upper()}"
+    return lang
+
+
+def detect_system_locale():
+    """Best-effort OS locale for headless runs, e.g. ``fr-FR``.
+
+    Returns ``DEFAULT_LOCALE`` when nothing usable can be found.
+    """
+    candidates = []
+
+    # Windows: ask Win32 for the user's default locale name (most accurate).
+    if os.name == "nt":
+        try:
+            import ctypes
+
+            buf = ctypes.create_unicode_buffer(85)
+            if ctypes.windll.kernel32.GetUserDefaultLocaleName(buf, len(buf)):
+                candidates.append(buf.value)
+        except Exception:
+            pass
+
+    # Standard-library locale readers (cross-platform).
+    try:
+        candidates.append(_locale.getlocale()[0])
+    except Exception:
+        pass
+    try:
+        # getdefaultlocale() is deprecated in 3.12 but remains the most
+        # reliable reader of the LANG environment; silence the warning.
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            candidates.append(_locale.getdefaultlocale()[0])
+    except Exception:
+        pass
+
+    # POSIX environment variables (LANGUAGE may be a colon-separated list).
+    for var in ("LC_ALL", "LC_MESSAGES", "LANG", "LANGUAGE"):
+        val = os.environ.get(var)
+        if val:
+            candidates.append(val.split(":")[0])
+
+    for cand in candidates:
+        norm = _normalize(cand)
+        if norm:
+            return norm
+
+    return DEFAULT_LOCALE
+
+
+def language_name(loc):
+    """Return the English language name for a locale (``fr-FR`` -> ``French``).
+
+    Falls back to the raw (normalized) locale string when the language is not
+    in the table; that still works fine as a hint for the model.
+    """
+    norm = _normalize(loc) or DEFAULT_LOCALE
+    lang = norm.split("-")[0].lower()
+    return _LANGUAGE_NAMES.get(lang, norm)
+
+
+def resolve_search_locale(settings, logger=None):
+    """Resolve the locale to use for query generation.
+
+    Priority:
+        1. Explicit ``search_locale`` setting, when set to something other
+           than ``"auto"``/empty (user override in the UI).
+        2. ``detected_locale`` reported by the GUI (``navigator.language``).
+        3. Python-side OS detection (headless/CLI).
+        4. ``DEFAULT_LOCALE``.
+
+    Args:
+        settings (dict): the global settings dict.
+        logger (callable, optional): logging function.
+
+    Returns:
+        str: a locale such as ``"fr-FR"``.
+    """
+    settings = settings or {}
+
+    raw = str(settings.get("search_locale") or "").strip()
+    if raw and raw.lower() != "auto":
+        norm = _normalize(raw)
+        if norm:
+            return norm
+
+    detected = _normalize(settings.get("detected_locale"))
+    if detected:
+        return detected
+
+    resolved = detect_system_locale()
+    if logger:
+        logger(f"Search locale auto-detected: {resolved}")
+    return resolved


### PR DESCRIPTION
## What

Adds an **optional** way to generate Bing search terms with an LLM, in the language of the machine running AutoRewarder, instead of always sampling the static English `assets/queries.json`.

This complements the ongoing *"Region & Language-specific search queries"* effort (see `CONTRIBUTING.md` and the roadmap): rather than shipping large per-locale wordlists, a user can bring their own LLM API key and get fresh, natural, localized queries on every run.

The feature is **off by default** — existing behavior is unchanged unless a user turns it on.

## How it works

- **Language detection.** In the desktop GUI the OS/browser locale is read from `navigator.language`; in headless/CLI runs it falls back to the Python `locale` module, the `LANG` family of env vars, and (on Windows) the Win32 user-default locale. The user can override it or leave it on `auto`.
- **Generation.** On each phase, if enabled and an API key is present, AutoRewarder asks the chosen provider for `count` fresh queries in the resolved language. Providers are bring-your-own-key and called over plain HTTP with the existing `requests` dependency (no new SDK): **OpenAI, Anthropic, Google Gemini**. Defaults use each provider's cheapest current small model, editable in the UI.
- **Robustness (never breaks a run).** Any failure — missing/invalid key, quota or rate-limit, offline, timeout, malformed response — logs a clear warning and falls back to the static `queries.json`. If the LLM returns fewer than `count` queries, the remainder is topped up from `queries.json` so the daily target is still met. Each phase (PC/Mobile) makes an independent call.

## Changes

- `src/search/locale.py` *(new)* — locale detection + language resolution.
- `src/search/llm.py` *(new)* — provider-agnostic query generation, fully fault-tolerant.
- `src/accounts/settings.py` — new global settings (`use_llm_queries`, `llm_provider`, `llm_model`, `llm_api_key`, `search_locale`, `detected_locale`).
- `src/api.py` — `_build_queries()` (LLM + fallback/top-up) wired into `_run_phase`; JS bridge methods `get/set_llm_config`, `set_detected_locale`.
- `gui/` — new "Search terms" group in the Settings modal (toggle, provider, model, API key, language) + wiring.
- Docs — USER_GUIDE section + README roadmap.

## Notes / trade-offs

- The API key is stored in plain text in `settings.json`, consistent with the rest of the app's settings. This is flagged in the UI hint and the User Guide.
- Only Google Gemini currently offers a genuine free API tier; OpenAI/Anthropic are pay-per-token (documented in the guide).
- No personal data is sent — the prompt only asks for generic queries in a given language.

## Testing

- Linting matches CI: `black --check .`, `flake8 .`, `mypy .` all pass.
- Enable in Settings with a valid key + "Hide browser", run a short PC phase → logs `Generating N queries via LLM (...)` and the history shows queries in the selected language.
- Invalid key / offline → warning + automatic fallback to `queries.json`; the run still completes.
- Feature off → behavior identical to `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI toggle to generate search terms in the selected language (with automatic locale detection).
  * Configure provider (OpenAI/Anthropic/Gemini), model, API key, and locale directly from the Settings modal.
  * When AI generation fails, the app automatically falls back to the built-in search terms.
* **Documentation**
  * Updated the user guide and roadmap with setup, privacy/storage details for the API key, and expected fallback/cost behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->