### PR TITLE
fix: visual search flow, claim button, and force toggles for daily tasks

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -23,6 +23,7 @@ Welcome! This guide will help you get started with AutoRewarder and explain all 
 - [Understanding the Settings](#understanding-the-settings)
 - [Rewards Dashboard](#rewards-dashboard)
 - [Hide Browser](#hide-browser)
+- [Force daily tasks & visual search](#force-daily-tasks--visual-search)
 - [Autostart & Daily Run Time](#autostart--daily-run-time)
 - [AI-generated search terms (LLM)](#ai-generated-search-terms-llm)
 - [Scheduled runs](#scheduled-runs)
@@ -152,6 +153,8 @@ If a new version is available, AutoRewarder can show an update notification and 
 
 If you've already done your searches manually (or just want to clean up the dashboard quickly), enable the **"Daily tasks only"** toggle before starting. The run skips both Bing search phases and goes straight to the Rewards dashboard to harvest the Daily Set/More Activities cards + Visual Search task.
 
+Anything already marked as done for today is skipped, and the log says so — see [Force daily tasks & visual search](#force-daily-tasks--visual-search) to run it again anyway.
+
 ### Visual Search
 
 This feature uses a rotating pool of base images, random cropping, and varied JPEG compression to create a large number of distinct upload variants, which helps the bot behave more like a real user while reducing the chance of hash-based detection.
@@ -194,6 +197,15 @@ This toggle controls whether you can see Microsoft Edge while searches are happe
 **Why would you use hide-browser?**
 - Less distracting if you're working on something else
 - Slightly faster performance since it doesn't have to render the browser window what will save system resources (RAM/CPU)
+
+### Force daily tasks & visual search
+
+AutoRewarder records, per account and per day, that the Daily Set and the Visual Search have been done, so a second run of the same day skips them. Two toggles in the **Daily tasks** group of the Settings window let you override that record:
+
+- **Force daily tasks:** runs the Daily Set and More Activities even when today is already marked as done. Cards that are genuinely complete are still skipped by the card-level detection, so a forced run on a real already-done day just confirms the state.
+- **Force visual search:** runs the visual search even when today is already marked as done. A different image is picked each time, so nothing is uploaded twice.
+
+Both are **off by default**, which keeps the normal behaviour: what already ran today is not redone. Turn one on when you don't trust the saved status — for instance a task that was marked as done but did not credit.
 
 ### AI-generated search terms (LLM)
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -161,11 +161,13 @@ This feature uses a rotating pool of base images, random cropping, and varied JP
 
 The visual-search flow is designed to:
 - run as part of the daily task cycle or after the PC phase, if the task is not already completed
+- start from the Rewards **"Visual search streak"** mission's own link, read off your dashboard — Rewards credits the mission only for a search started there, so a search from a bare `bing.com` runs without ever ticking it
 - produce 54,684 unique variations per image, generating over 1.6 million different upload variants to keep your account safe
 - keep the process human-like with natural mouse movement, randomized delays, and natural page scrolling after upload
+- re-read the mission's progress afterwards (`Activity: 0/1` → `1/1`) and leave the day unmarked when Rewards did not count the search, so the next run tries again
 
 > [!NOTE]
-> The app tracks visual-search completion per day and per account, so the task does not get repeated.
+> The app tracks visual-search completion per day and per account, so the task does not get repeated. Enable **"Force visual search"** in the Settings window to run it again anyway.
 
 ### After Completion
 

--- a/gui/index.html
+++ b/gui/index.html
@@ -64,7 +64,7 @@
     <!-- ==================== Run card ==================== -->
     <section class="card run-card">
       <div class="run-top">
-        <label class="toggle-row" title="Skip searches; only complete the daily Rewards tasks">
+        <label class="toggle-row" title="Skip searches; only complete the daily Rewards tasks and the visual search">
           <input type="checkbox" id="dailyOnlyToggle">
           <span class="toggle-pill"></span>
           <span class="toggle-label">Daily tasks only</span>
@@ -218,6 +218,33 @@
             </div>
             <span class="toggle-compact">
               <input type="checkbox" id="closeToTrayToggle">
+              <span class="toggle-pill"></span>
+            </span>
+          </label>
+        </section>
+
+        <section class="settings-group">
+          <div class="settings-group-title">Daily tasks</div>
+          <p class="settings-group-hint">
+            A task that already ran today is skipped on the next run. Turn these on to run it again anyway.
+          </p>
+          <label class="settings-row">
+            <div class="settings-row-text">
+              <div class="settings-row-label">Force daily tasks</div>
+              <div class="settings-row-hint">Run the Daily Set and More Activities even when today is already marked as done. Cards that are genuinely complete are still skipped.</div>
+            </div>
+            <span class="toggle-compact">
+              <input type="checkbox" id="forceDailyToggle">
+              <span class="toggle-pill"></span>
+            </span>
+          </label>
+          <label class="settings-row">
+            <div class="settings-row-text">
+              <div class="settings-row-label">Force visual search</div>
+              <div class="settings-row-hint">Run the visual search even when today is already marked as done. A different image is used each time.</div>
+            </div>
+            <span class="toggle-compact">
+              <input type="checkbox" id="forceVisualToggle">
               <span class="toggle-pill"></span>
             </span>
           </label>

--- a/gui/script.js
+++ b/gui/script.js
@@ -678,7 +678,8 @@ function open_settings_modal() {
     pywebview.api.get_launch_on_startup(),
     pywebview.api.get_close_to_tray(),
     pywebview.api.get_llm_config(),
-  ]).then(([schedules, startup, closeToTray, llmConfig]) => {
+    pywebview.api.get_force_tasks(),
+  ]).then(([schedules, startup, closeToTray, llmConfig, forceTasks]) => {
     render_schedule_cards(schedules || []);
 
     // Start-with-Windows toggle — disable row on unsupported OS.
@@ -701,6 +702,13 @@ function open_settings_modal() {
     if (trayToggle) {
       trayToggle.checked = closeToTray !== false;
     }
+
+    // Force toggles — default to off if the API failed.
+    const force = forceTasks || {};
+    const forceDailyToggle = document.getElementById('forceDailyToggle');
+    const forceVisualToggle = document.getElementById('forceVisualToggle');
+    if (forceDailyToggle) forceDailyToggle.checked = Boolean(force.force_daily_tasks);
+    if (forceVisualToggle) forceVisualToggle.checked = Boolean(force.force_visual_search);
 
     // LLM search-term generation.
     const cfg = llmConfig || {};
@@ -1068,6 +1076,14 @@ async function save_settings() {
     await Promise.all(payloads.map(p =>
       pywebview.api.set_dashboard_variant(p.id, p.dashboardVariant)
     ));
+
+    // Persist the force toggles (independent of the schedule slicing).
+    const forceDailyEl = document.getElementById('forceDailyToggle');
+    const forceVisualEl = document.getElementById('forceVisualToggle');
+    await pywebview.api.set_force_tasks(
+      Boolean(forceDailyEl && forceDailyEl.checked),
+      Boolean(forceVisualEl && forceVisualEl.checked)
+    );
 
     // Persist LLM search-term config (independent of the schedule slicing).
     const llmToggleEl = document.getElementById('llmToggle');

--- a/src/accounts/settings.py
+++ b/src/accounts/settings.py
@@ -97,6 +97,13 @@ class GlobalSettingsManager:
             # introduced in v3.3; users who prefer the standard X = quit
             # can flip it off in Settings. Read once at app startup.
             "close_to_tray": True,
+            # "Run it anyway" overrides. status.json remembers what already
+            # ran today so a second run of the day skips it; these let the
+            # user re-run a task whose saved status they don't trust (e.g. a
+            # Daily Set card that stayed uncredited, or a visual search that
+            # failed after being marked as done).
+            "force_daily_tasks": False,
+            "force_visual_search": False,
             # Default query counts.
             "queries_pc": 30,
             "queries_mobile": 20,
@@ -170,6 +177,29 @@ class GlobalSettingsManager:
         """Persist the current account id in settings."""
         settings = self.get_settings()
         settings["current_account_id"] = account_id
+        self.save_settings(settings)
+
+    def get_force_tasks(self):
+        """Return the force flags for the daily tasks and the visual search."""
+        settings = self.get_settings()
+        return {
+            "force_daily_tasks": bool(settings.get("force_daily_tasks", False)),
+            "force_visual_search": bool(settings.get("force_visual_search", False)),
+        }
+
+    def set_force_tasks(self, force_daily_tasks, force_visual_search):
+        """
+        Persist the force flags.
+
+        Args:
+            force_daily_tasks (bool): Run the Daily Set even when today is
+                already marked as done.
+            force_visual_search (bool): Run the visual search even when today
+                is already marked as done.
+        """
+        settings = self.get_settings()
+        settings["force_daily_tasks"] = bool(force_daily_tasks)
+        settings["force_visual_search"] = bool(force_visual_search)
         self.save_settings(settings)
 
     def get_queries_pc(self):

--- a/src/accounts/settings.py
+++ b/src/accounts/settings.py
@@ -8,27 +8,47 @@ from ..config import APP_DIR, GLOBAL_SETTINGS_PATH
 SCHEMA_VERSION = 3
 
 
+# Returned by _read_json when the file is there but couldn't be read. Distinct
+# from `default`, which means "there is nothing to read": a file we failed to
+# read still holds the user's settings, and must never be written over.
+UNREADABLE = object()
+
+
 def _read_json(path, default):
-    """Read a JSON file. On any parse/IO failure, back it up as .backup and return default."""
+    """
+    Read a JSON file.
+
+    A file whose content is malformed is moved aside as .backup and `default` is
+    returned — the file is beyond saving. A file that merely can't be opened
+    right now (a Windows lock from Defender, the indexer, or a second instance
+    mid-write) is retried and then reported as UNREADABLE, and left untouched:
+    quarantining it there used to cost the user every setting they had.
+    """
+    import time as _time
+
     if not os.path.exists(path):
         return default
 
-    try:
-        with open(path, "r", encoding="utf-8") as file:
-            data = json.load(file)
-            return data
-    except (json.JSONDecodeError, UnicodeDecodeError, ValueError, OSError):
-        backup_path = path + ".backup"
-        if os.path.exists(backup_path):
+    for attempt in range(4):
+        try:
+            with open(path, "r", encoding="utf-8") as file:
+                return json.load(file)
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+            backup_path = path + ".backup"
+            if os.path.exists(backup_path):
+                try:
+                    os.remove(backup_path)
+                except OSError:
+                    pass
             try:
-                os.remove(backup_path)
+                os.replace(path, backup_path)
             except OSError:
                 pass
-        try:
-            os.replace(path, backup_path)
+            return default
         except OSError:
-            pass
-        return default
+            _time.sleep(0.15 * (attempt + 1))
+
+    return UNREADABLE
 
 
 def _write_json(path, data):
@@ -80,6 +100,11 @@ class GlobalSettingsManager:
 
     def __init__(self):
         self.path = GLOBAL_SETTINGS_PATH
+        # Last settings read successfully, and whether the most recent read was
+        # authoritative. A locked file must not turn into defaults, and must
+        # not be written over by a setter working from those defaults.
+        self._last_good = None
+        self._read_ok = True
 
     def get_settings(self):
         """Return settings merged with defaults."""
@@ -139,6 +164,13 @@ class GlobalSettingsManager:
             return defaults
 
         settings = _read_json(self.path, None)
+
+        if settings is UNREADABLE:
+            # The file is there and still holds the real values; hand back what
+            # we last read (or defaults on a first read) and write nothing.
+            self._read_ok = False
+            return dict(self._last_good) if self._last_good else defaults
+
         if not isinstance(settings, dict):
             # Recovery path: recreate defaults. If the write fails (e.g.
             # transient Windows lock), don't crash the read — caller still
@@ -151,21 +183,41 @@ class GlobalSettingsManager:
 
         # Fill missing defaults without clobbering existing keys.
         merged = {**defaults, **settings}
+        self._last_good = dict(merged)
+        self._read_ok = True
         return merged
 
     def save_settings(self, settings):
         """Persist settings to disk."""
         _write_json(self.path, settings)
 
+    def settings_for_update(self):
+        """
+        Settings to modify then save back.
+
+        Raises:
+            OSError: When the file exists but couldn't be read, so the values in
+                hand aren't the ones on disk. Saving them would wipe whatever it
+                really holds; the caller reports the failure instead.
+        """
+        settings = self.get_settings()
+
+        if not self._read_ok:
+            raise OSError(
+                f"{self.path} is locked; not overwriting it with stale values"
+            )
+
+        return settings
+
     def set_hide_browser(self, is_hide):
         """Update the hide_browser flag in settings."""
-        settings = self.get_settings()
+        settings = self.settings_for_update()
         settings["hide_browser"] = bool(is_hide)
         self.save_settings(settings)
 
     def set_close_to_tray(self, value):
         """Update the close_to_tray flag in settings."""
-        settings = self.get_settings()
+        settings = self.settings_for_update()
         settings["close_to_tray"] = bool(value)
         self.save_settings(settings)
 
@@ -175,13 +227,13 @@ class GlobalSettingsManager:
 
     def set_current_account_id(self, account_id):
         """Persist the current account id in settings."""
-        settings = self.get_settings()
+        settings = self.settings_for_update()
         settings["current_account_id"] = account_id
         self.save_settings(settings)
 
     def get_force_tasks(self):
         """Return the force flags for the daily tasks and the visual search."""
-        settings = self.get_settings()
+        settings = self.settings_for_update()
         return {
             "force_daily_tasks": bool(settings.get("force_daily_tasks", False)),
             "force_visual_search": bool(settings.get("force_visual_search", False)),
@@ -197,7 +249,7 @@ class GlobalSettingsManager:
             force_visual_search (bool): Run the visual search even when today
                 is already marked as done.
         """
-        settings = self.get_settings()
+        settings = self.settings_for_update()
         settings["force_daily_tasks"] = bool(force_daily_tasks)
         settings["force_visual_search"] = bool(force_visual_search)
         self.save_settings(settings)
@@ -208,7 +260,7 @@ class GlobalSettingsManager:
 
     def set_queries_pc(self, count):
         """Persist the PC queries count in settings."""
-        settings = self.get_settings()
+        settings = self.settings_for_update()
         settings["queries_pc"] = max(0, min(130, int(count)))
         self.save_settings(settings)
 
@@ -218,7 +270,7 @@ class GlobalSettingsManager:
 
     def set_queries_mobile(self, count):
         """Persist the mobile queries count in settings."""
-        settings = self.get_settings()
+        settings = self.settings_for_update()
         settings["queries_mobile"] = max(0, min(99, int(count)))
         self.save_settings(settings)
 
@@ -255,7 +307,7 @@ class GlobalSettingsManager:
 
         locale = str(search_locale or "").strip() or "auto"
 
-        settings = self.get_settings()
+        settings = self.settings_for_update()
         settings["use_llm_queries"] = bool(use_llm_queries)
         settings["llm_provider"] = provider
         settings["llm_model"] = str(model or "").strip()
@@ -265,7 +317,7 @@ class GlobalSettingsManager:
 
     def set_detected_locale(self, locale):
         """Persist the locale reported by the GUI (navigator.language)."""
-        settings = self.get_settings()
+        settings = self.settings_for_update()
         settings["detected_locale"] = str(locale or "").strip()
         self.save_settings(settings)
 

--- a/src/api.py
+++ b/src/api.py
@@ -127,6 +127,11 @@ class AutoRewarderAPI:
             "quests": 0,
         }
         self._last_scraped_balance = None
+        # Whether the Daily Set / visual search already ran in this main() call.
+        # A "Force …" setting is persistent, so without these the PC batches of
+        # an advanced schedule would each redo the task (and re-upload an image).
+        self._daily_set_attempted = False
+        self._visual_search_attempted = False
         # Last balance-scrape diagnostic ({value, via, candidates, url, title}),
         # surfaced to the dashboard so a failed read can be debugged in place.
         self._last_balance_debug = {}
@@ -448,6 +453,30 @@ class AutoRewarderAPI:
         self.global_settings.set_close_to_tray(value)
         state = "ON (X → tray)" if value else "OFF (X → quit)"
         self.log(f"Close-to-tray: {state}. Restart to apply.")
+
+    def get_force_tasks(self):
+        """Return the force flags for the daily tasks and the visual search."""
+        return self.global_settings.get_force_tasks()
+
+    def set_force_tasks(self, force_daily_tasks, force_visual_search):
+        """
+        Persist the "run even if already done today" toggles.
+
+        Args:
+            force_daily_tasks (bool): Run the Daily Set even when status.json
+                says it is already done today.
+            force_visual_search (bool): Run the visual search even when
+                status.json says it is already done today.
+
+        Returns:
+            bool: True once the flags are saved.
+        """
+        self.global_settings.set_force_tasks(force_daily_tasks, force_visual_search)
+        self.log(
+            f"Force daily tasks: {'ON' if force_daily_tasks else 'OFF'} — "
+            f"Force visual search: {'ON' if force_visual_search else 'OFF'}"
+        )
+        return True
 
     def get_queries_counts(self):
         """
@@ -2227,6 +2256,8 @@ class AutoRewarderAPI:
             "quests": 0,
         }
         self._last_scraped_balance = None
+        self._daily_set_attempted = False
+        self._visual_search_attempted = False
 
         try:
             if daily_only:
@@ -2351,48 +2382,60 @@ class AutoRewarderAPI:
         Open a PC driver, run only the Daily Set + More Activities, scrape
         the points balance, then quit. No Bing searches are performed.
 
-        Unlike the normal flow, this path is user-initiated (explicit toggle)
-        so it ignores `should_perform_daily_set()` — if the saved status says
-        "done today" but the user clicked Start anyway, they want it to run.
-        The card-level detection inside perform_daily_set will skip cards
-        that are genuinely complete, so re-running on a real already-done day
-        just confirms state without wasting clicks.
+        A task already marked as done today is skipped, unless the matching
+        "Force daily tasks" / "Force visual search" setting is on. When forced,
+        the card-level detection inside perform_daily_set still skips cards that
+        are genuinely complete, and the visual search picks an image it has not
+        used recently, so re-running on a real already-done day just confirms
+        state without wasting clicks.
         """
         if self.daily_set is None:
             self.log("[ERROR] Daily tasks unavailable for this account.")
             return
 
-        if not self.daily_set.should_perform_daily_set():
-            self.log(
-                "Note: today is already marked as done in status.json, "
-                "but running anyway since you asked explicitly."
-            )
+        force = self.global_settings.get_force_tasks()
+        daily_done = not self.daily_set.should_perform_daily_set()
+        run_daily_set = not daily_done or force["force_daily_tasks"]
 
         self.log("=== Daily tasks and Visual Search only ===")
 
+        if daily_done and run_daily_set:
+            self.log(
+                "Daily tasks already marked as done today, but running anyway "
+                "(Force daily tasks is ON)."
+            )
+
         self._driver = self.driver_manager.setup_driver(mobile=False)
         try:
-            human = HumanBehavior(self._driver, show_cursor=True, mobile=False)
-            success = self.daily_set.perform_daily_set(
-                self._driver, human, stop_event=self._stop_event
-            )
-            # Record cards completed + scrape the balance while we're still on
-            # the rewards dashboard, before any Stop check returns early.
-            totals = self.daily_set.last_totals
-            self._session_counts["cards"] += totals.get("newly", 0)
-            self._session_counts["earn"] += totals.get("earn", 0)
-            self._session_counts["quests"] += totals.get("quests", 0)
-            self._try_scrape_balance()
-            if self._stop_event.is_set():
-                self.log("Daily tasks aborted by Stop.")
-                return
-            if success:
-                self.daily_set.mark_as_completed()
-                self.log("Daily tasks completed and marked as done for today.")
+            if run_daily_set:
+                self._daily_set_attempted = True
+                human = HumanBehavior(self._driver, show_cursor=True, mobile=False)
+                success = self.daily_set.perform_daily_set(
+                    self._driver, human, stop_event=self._stop_event
+                )
+                # Record cards completed + scrape the balance while we're still
+                # on the rewards dashboard, before any Stop check returns early.
+                totals = self.daily_set.last_totals
+                self._session_counts["cards"] += totals.get("newly", 0)
+                self._session_counts["earn"] += totals.get("earn", 0)
+                self._session_counts["quests"] += totals.get("quests", 0)
+                self._try_scrape_balance()
+                if self._stop_event.is_set():
+                    self.log("Daily tasks aborted by Stop.")
+                    return
+                if success:
+                    self.daily_set.mark_as_completed()
+                    self.log("Daily tasks completed and marked as done for today.")
+                else:
+                    self.log("Daily tasks failed. Not marked as done for today.")
             else:
-                self.log("Daily tasks failed. Not marked as done for today.")
+                self.log(
+                    "Daily tasks already completed today. Skipping. "
+                    "(Enable 'Force daily tasks' in Settings to run them anyway.)"
+                )
+                self._try_scrape_balance()
 
-            # Run visual search if needed, even if the Daily Set failed
+            # Run the visual search even if the Daily Set failed or was skipped.
             if not self._stop_event.is_set():
                 self._run_visual_search_if_needed()
 
@@ -2484,17 +2527,38 @@ class AutoRewarderAPI:
         Checks if the task is needed today, generates a unique image,
         performs the search, and updates the status after successful completion.
 
+        A day already marked as done is skipped, unless the "Force visual
+        search" setting is on — the saved status can be stale (a search that
+        was credited but is worth redoing, or a status file the user doesn't
+        trust), and that toggle is how the user says so.
+
         Returns:
             bool: True if visual search was performed, False otherwise.
         """
         if self.daily_set is None or self.search_engine is None:
             return False
 
-        if not self.daily_set.should_perform_visual_search():
+        force = (
+            not self._visual_search_attempted
+            and self.global_settings.get_force_tasks()["force_visual_search"]
+        )
+        already_done = not self.daily_set.should_perform_visual_search()
+
+        if already_done and not force:
             self.log("Visual Search already completed today. Skipping.")
             return False
 
-        self.log("Visual Search not completed today. Starting Visual Search task...")
+        if already_done:
+            self.log(
+                "Visual Search already marked as done today, but running anyway "
+                "(Force visual search is ON)."
+            )
+        else:
+            self.log(
+                "Visual Search not completed today. Starting Visual Search task..."
+            )
+
+        self._visual_search_attempted = True
 
         used_images = self.daily_set.get_used_visual_search_images()
 
@@ -2567,17 +2631,39 @@ class AutoRewarderAPI:
             self._session_counts[bucket] += int(done or 0)
 
             ran_daily_set = False
+
+            # Only the PC phase runs the Daily Set, and a day already marked as
+            # done is skipped unless "Force daily tasks" is on.
+            daily_done = False
+            force_daily = False
+            if do_daily_set and self.daily_set is not None:
+                daily_done = not self.daily_set.should_perform_daily_set()
+                force_daily = (
+                    not self._daily_set_attempted
+                    and self.global_settings.get_force_tasks()["force_daily_tasks"]
+                )
+
             if (
                 do_daily_set
+                and self.daily_set is not None
                 and not self._stop_event.is_set()
-                and self.daily_set.should_perform_daily_set()
+                and (not daily_done or force_daily)
             ):
-                self.log("Daily Set not completed today. Starting Daily Set tasks...")
+                if daily_done:
+                    self.log(
+                        "Daily Set already marked as done today, but running "
+                        "anyway (Force daily tasks is ON)."
+                    )
+                else:
+                    self.log(
+                        "Daily Set not completed today. Starting Daily Set tasks..."
+                    )
                 human = HumanBehavior(self._driver, show_cursor=True, mobile=mobile)
                 success = self.daily_set.perform_daily_set(
                     self._driver, human, stop_event=self._stop_event
                 )
                 ran_daily_set = True
+                self._daily_set_attempted = True
                 # Record cards + scrape the balance while still on the rewards
                 # dashboard, before the Stop check can short-circuit.
                 totals = self.daily_set.last_totals
@@ -2593,6 +2679,12 @@ class AutoRewarderAPI:
                         )
                     else:
                         self.log("Daily Set failed. Not marked as done for today.")
+
+            elif daily_done and not self._stop_event.is_set():
+                self.log(
+                    "Daily Set already completed today. Skipping. "
+                    "(Enable 'Force daily tasks' in Settings to run it anyway.)"
+                )
 
             # Visual search runs only in PC phase,
             # do_daily_set=False in Mobile phase.

--- a/src/api.py
+++ b/src/api.py
@@ -2574,14 +2574,38 @@ class AutoRewarderAPI:
                 self._driver,
                 image_path,
                 stop_event=self._stop_event,
+                entry_url=getattr(self.daily_set, "visual_search_url", None),
             )
 
-            if success:
-                self.daily_set.save_used_visual_search_images(updated_images)
-                self.daily_set.mark_visual_search_as_completed()
-                self.log("Visual search marked as done for today.")
+            # Rewards is the authority, in both directions: a results page is
+            # not proof of credit, and Bing rendering the results somewhere we
+            # didn't recognise is not proof of failure. So ask the mission.
+            stopped = self._stop_event is not None and self._stop_event.is_set()
+            credited = None if stopped else self._check_visual_search_credited()
 
-            return success
+            # The image reached Bing in either of these cases, so don't offer it
+            # again on the next run.
+            if success or credited is True:
+                self.daily_set.save_used_visual_search_images(updated_images)
+
+            if not success:
+                if credited is not True:
+                    return False
+                self.log(
+                    "Bing's results page never loaded, but Rewards counted the "
+                    "search anyway."
+                )
+            elif credited is False:
+                self.log(
+                    "[WARNING] Rewards did not count the visual search. "
+                    "Not marked as done for today."
+                )
+                return False
+
+            self.daily_set.mark_visual_search_as_completed()
+            self.log("Visual search marked as done for today.")
+
+            return True
 
         except Exception as e:
             self.log(f"[WARNING] Visual search failed: {e}")
@@ -2593,6 +2617,32 @@ class AutoRewarderAPI:
                     os.remove(image_path)
                 except Exception as e:
                     self.log(f"[WARNING] Failed to remove temporary image file: {e}")
+
+    def _check_visual_search_credited(self):
+        """
+        Check the Rewards "visual search streak" mission after a search.
+
+        Returns:
+            bool: True when the mission counted the search, False when it
+                explicitly still shows no activity today, or None when there
+                is nothing to compare against (legacy dashboard, mission not
+                offered, or the progress couldn't be read).
+        """
+        try:
+            progress = self.daily_set.read_visual_search_progress(self._driver)
+        except Exception as e:
+            self.log(f"[WARNING] Could not read the visual search mission: {e}")
+            return None
+
+        if progress is None:
+            return None
+
+        done, total = progress
+        before = getattr(self.daily_set, "visual_search_progress", None)
+        was = f" (was {before[0]}/{before[1]})" if before else ""
+        self.log(f"Rewards visual search streak: {done}/{total}{was}")
+
+        return done > 0
 
     def _run_phase(self, mobile, count, do_daily_set):
         """

--- a/src/api.py
+++ b/src/api.py
@@ -734,7 +734,11 @@ class AutoRewarderAPI:
         account's meta.json, so we just drop the global one. Anything
         valuable was already migrated during a previous upgrade cycle.
         """
-        settings = self.global_settings.get_settings()
+        try:
+            settings = self.global_settings.settings_for_update()
+        except OSError as e:
+            self._safe_log(f"[WARNING] Could not read settings.json: {e}")
+            return
         if "schedule" in settings:
             settings.pop("schedule", None)
             self.global_settings.save_settings(settings)
@@ -855,7 +859,7 @@ class AutoRewarderAPI:
 
         # Mark current schema applied so we don't re-run unnecessarily.
         try:
-            settings = self.global_settings.get_settings()
+            settings = self.global_settings.settings_for_update()
             settings["autostart_schema_version"] = self._AUTOSTART_SCHEMA_VERSION
             self.global_settings.save_settings(settings)
         except Exception:
@@ -1361,7 +1365,11 @@ class AutoRewarderAPI:
 
         # Persist user intent FIRST so _sync_account_autostart reads the
         # new value when it queries is_autostart_enabled().
-        settings = self.global_settings.get_settings()
+        try:
+            settings = self.global_settings.settings_for_update()
+        except OSError as e:
+            self.log(f"[ERROR] Could not save the autostart setting: {e}")
+            return False
         settings["autoStartUp"] = bool(enable)
         self.global_settings.save_settings(settings)
 
@@ -1412,9 +1420,12 @@ class AutoRewarderAPI:
         ok = self._set_autostart_registry(bool(enabled))
         if ok:
             # Mirror the state into global settings.json for the UI.
-            settings = self.global_settings.get_settings()
-            settings["autoStartUp"] = bool(enabled)
-            self.global_settings.save_settings(settings)
+            try:
+                settings = self.global_settings.settings_for_update()
+                settings["autoStartUp"] = bool(enabled)
+                self.global_settings.save_settings(settings)
+            except OSError as e:
+                self._safe_log(f"[WARNING] Could not mirror autostart state: {e}")
         return ok
 
     # ------------------------------------------------------------------

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -226,6 +226,108 @@ try {
 """
 
 
+# Find the "visual search streak" mission's own entry URL. Rewards credits the
+# streak only for a search started from that link (the Bing homepage carrying
+# the mission's promo code, e.g. /?features=vsstreak,vstooltip&form=ML2XES), so
+# a search from a bare bing.com runs but never ticks the mission. The URL lives
+# in the streamed RSC payload; a rendered <a> is preferred when the mission
+# flyout happens to be open. Matched on the "vsstreak" feature flag, so it stays
+# language- and market-independent.
+_FIND_VS_STREAK_URL_JS = r"""
+try {
+  var a = document.querySelector('a[href*="vsstreak"]');
+  if (a && a.href) return a.href;
+  var raw = window.__next_f || [];
+  var parts = [];
+  for (var n = 0; n < raw.length; n++) {
+    var e = raw[n];
+    if (Array.isArray(e)) { if (typeof e[1] === 'string') parts.push(e[1]); }
+    else if (typeof e === 'string') { parts.push(e); }
+  }
+  var blob = parts.join('');
+  var idx = blob.indexOf('vsstreak');
+  if (idx < 0) return null;
+  var start = blob.lastIndexOf('http', idx);
+  if (start < 0) return null;
+  // Stop at a quote or whitespace only: the URL itself contains a comma
+  // (features=vsstreak,vstooltip) and backslash-escaped slashes.
+  var stop = '"\'`\n\r\t <>';
+  var end = idx;
+  while (end < blob.length && stop.indexOf(blob[end]) < 0) end++;
+  var url = blob.slice(start, end)
+    .replace(/\\u0026/g, '&')
+    .replace(/\\\//g, '/');
+  return url.indexOf('bing.com') >= 0 ? url : null;
+} catch (e) { return null; }
+"""
+
+# Read the progress of the "visual search streak" mission ("Activité : 0/1").
+# The card is identified by its own artwork (OMR.VisualSearch.VNext…, or the
+# search_visual.svg mission icon) rather than its localized title, and progress
+# comes from the react-aria progressbar when present, else from the card's
+# "<done>/<total>" counter. This is what says whether Rewards actually counted
+# the search we just made.
+_VS_STREAK_PROGRESS_JS = r"""
+try {
+  var imgs = document.querySelectorAll(
+    'img[src*="VisualSearch"], img[src*="search_visual"]'
+  );
+  for (var i = 0; i < imgs.length; i++) {
+    var card = imgs[i].parentElement;
+    for (var up = 0; card && up < 8; up++) {
+      var bar = card.querySelector('[role="progressbar"][aria-valuemax]');
+      if (bar) {
+        var now = parseInt(bar.getAttribute('aria-valuenow'), 10);
+        var max = parseInt(bar.getAttribute('aria-valuemax'), 10);
+        if (!isNaN(now) && !isNaN(max) && max > 0) return {done: now, total: max};
+      }
+      var m = (card.textContent || '').replace(/\s+/g, ' ').match(/(\d+)\s*\/\s*(\d+)/);
+      if (m) return {done: parseInt(m[1], 10), total: parseInt(m[2], 10)};
+      card = card.parentElement;
+    }
+  }
+  return null;
+} catch (e) { return null; }
+"""
+
+# Locate the primary control of the claim panel, language-independently.
+# The panel used to be a flyout ([class*="bg-flyout"]) holding a
+# <button class="...bgCtrlBrandRest...">; the dashboard now renders a react-aria
+# pressable card whose brand styling sits on an inner <div>. So match the brand
+# design token, then walk up to whatever is actually pressable. A brand control
+# wrapping the coins icon wins over any other brand CTA on the page.
+_FIND_CLAIM_CONTROL_JS = r"""
+try {
+  var scoped = document.querySelectorAll('[class*="bg-flyout"], [role="dialog"]');
+  var roots = Array.prototype.slice.call(scoped);
+  var isScoped = roots.length > 0;
+  if (!isScoped) roots = [document.body];
+  var fallback = null;
+  for (var r = 0; r < roots.length; r++) {
+    var brands = roots[r].querySelectorAll('[class*="bgCtrlBrand"]');
+    for (var i = 0; i < brands.length; i++) {
+      var el = brands[i];
+      if (!el.getClientRects().length) continue;
+      var press = el.closest(
+        'button, [role="button"], [data-react-aria-pressable]'
+      ) || el;
+      if (press.disabled) continue;
+      if (press.getAttribute('slot')) continue;
+      if ((press.getAttribute('aria-disabled') || '') === 'true') continue;
+      if (press.hasAttribute('data-disabled')) continue;
+      if (press.querySelector('img[src*="CoinsTransparent"]')) return press;
+      // Inside a flyout/dialog the only brand control is the claim CTA, so it
+      // is a safe fallback. On the bare page it could be any other dashboard
+      // CTA (redeem, promo banner), and clicking that would be worse than
+      // giving up — so don't guess there.
+      if (isScoped && !fallback) fallback = press;
+    }
+  }
+  return fallback;
+} catch (e) { return null; }
+"""
+
+
 class NewDashboardDailySet:
     """Daily Set handler for the new Next.js Microsoft Rewards dashboard."""
 
@@ -249,6 +351,13 @@ class NewDashboardDailySet:
             "earn": 0,
             "quests": 0,
         }
+        # Entry URL of the "visual search streak" mission, read off the
+        # dashboard during `perform` so the visual search can start from the
+        # link that credits it. None when the mission isn't offered.
+        self.visual_search_url = None
+        # Its progress as (done, total) before this run touched anything, or
+        # None when the mission isn't offered / couldn't be read.
+        self.visual_search_progress = None
 
     def _log(self, message):
         if self.logger:
@@ -625,6 +734,10 @@ class NewDashboardDailySet:
         claim/earn/quest passes are best-effort.
         """
         daily_ok = self._run_daily_set(driver, human, stop_event=stop_event)
+        self.visual_search_url = self._find_visual_search_url(driver)
+        self.visual_search_progress = self.read_visual_search_progress(
+            driver, navigate=False
+        )
         if stop_event is not None and stop_event.is_set():
             return daily_ok
         try:
@@ -648,6 +761,112 @@ class NewDashboardDailySet:
                 self._log(f"[WARNING] Quest pass failed: {e}")
         return daily_ok
 
+    def _find_visual_search_url(self, driver):
+        """
+        Return the "visual search streak" mission's entry URL, or None.
+
+        Called while the dashboard is loaded; the caller passes the URL to the
+        visual search so the search credits the mission.
+        """
+        try:
+            url = driver.execute_script(_FIND_VS_STREAK_URL_JS)
+        except Exception:
+            return None
+
+        if not isinstance(url, str) or not url.startswith("http"):
+            return None
+
+        self._log(f"Visual search streak mission link: {url}")
+        return url
+
+    def read_visual_search_progress(self, driver, navigate=True):
+        """
+        Read the "visual search streak" mission progress from the dashboard.
+
+        Args:
+            driver: Selenium WebDriver instance.
+            navigate (bool): Load the dashboard first. Pass False when the
+                dashboard is already the current page.
+
+        Returns:
+            tuple: (done, total) — e.g. (0, 1) before today's search and (1, 1)
+                once Rewards counted it — or None when the mission isn't
+                offered or the progress can't be read.
+        """
+        try:
+            if navigate:
+                driver.get(DASHBOARD_URL)
+                self._wait_ready(driver)
+                time.sleep(random.uniform(1.5, 2.5))
+            data = driver.execute_script(_VS_STREAK_PROGRESS_JS)
+        except Exception:
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        try:
+            return int(data["done"]), int(data["total"])
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    def _find_claim_tile(self, driver):
+        """
+        Find the dashboard "ready to claim" tile.
+
+        It is a clickable (non-link) card with the coins icon and a danger-status
+        dot for the pending points. The balance tile shows the same coins icon
+        but is an <a href="/redeem"> with no danger dot, so it is excluded.
+        Matched by design-system tokens only, never by localized labels.
+
+        Returns:
+            tuple: (tile element or None, pending points as a string).
+        """
+        try:
+            icons = driver.find_elements(
+                By.CSS_SELECTOR, 'img[src*="CoinsTransparent"]'
+            )
+        except Exception:
+            icons = []
+
+        for icon in icons:
+            try:
+                anc = icon.find_element(
+                    By.XPATH,
+                    "./ancestor::*[contains(@class,'cursor-pointer')][1]",
+                )
+                if anc.tag_name.lower() == "a":
+                    continue
+                if not anc.find_elements(By.CSS_SELECTOR, '[class*="statusDanger"]'):
+                    continue
+                try:
+                    pending = anc.find_element(
+                        By.CSS_SELECTOR, ".text-pageHeader"
+                    ).text.strip()
+                except Exception:
+                    pending = ""
+                return anc, pending
+            except Exception:
+                continue
+
+        return None, ""
+
+    def _find_claim_control(self, driver, timeout=10):
+        """
+        Wait for the claim panel opened by the tile and return its primary control.
+
+        Returns:
+            WebElement: The element to click, or None if none appeared in time.
+        """
+        try:
+            return WebDriverWait(driver, timeout).until(
+                lambda d: d.execute_script(_FIND_CLAIM_CONTROL_JS)
+            )
+        except TimeoutException:
+            return None
+        except Exception:
+            return None
+
     def _run_claim(self, driver, human, stop_event=None):
         """
         Claim pending points from the dashboard "ready to claim" tile.
@@ -668,43 +887,13 @@ class NewDashboardDailySet:
             self._log(f"[WARNING] Could not open the dashboard to claim: {e}")
             return
 
-        # The claim tile: a clickable (non-link) card with the coins icon and a
-        # danger-status dot (pending points). The balance tile also shows a coins
-        # icon but is an <a href="/redeem"> with no danger dot, so it's excluded.
-        card = None
-        pending = ""
-        try:
-            icons = driver.find_elements(
-                By.CSS_SELECTOR, 'img[src*="CoinsTransparent"]'
-            )
-        except Exception:
-            icons = []
-        for icon in icons:
-            try:
-                anc = icon.find_element(
-                    By.XPATH,
-                    "./ancestor::*[contains(@class,'cursor-pointer')][1]",
-                )
-                if anc.tag_name.lower() == "a":
-                    continue
-                if not anc.find_elements(By.CSS_SELECTOR, '[class*="statusDanger"]'):
-                    continue
-                card = anc
-                try:
-                    pending = anc.find_element(
-                        By.CSS_SELECTOR, ".text-pageHeader"
-                    ).text.strip()
-                except Exception:
-                    pending = ""
-                break
-            except Exception:
-                continue
+        card, pending = self._find_claim_tile(driver)
 
         if card is None:
             self._log("No claimable points.")
             return
 
-        self._log(f"Opening claim flyout (pending: {pending or '?'} points).")
+        self._log(f"Opening claim panel (pending: {pending or '?'} points).")
         try:
             driver.execute_script(
                 "arguments[0].scrollIntoView({block:'center'});", card
@@ -717,30 +906,27 @@ class NewDashboardDailySet:
             self._log(f"[WARNING] Could not open the claim flyout: {e}")
             return
 
-        # Wait for the flyout, then click its primary (brand) button — not the
-        # close (slot="close") or the "how it works" disclosure (slot="trigger").
-        if not self._wait_for(driver, '[class*="bg-flyout"]', timeout=10):
-            self._log("[WARNING] Claim flyout did not open.")
-            return
+        # Then click the panel's primary (brand) control — not the close
+        # (slot="close") or the "how it works" disclosure (slot="trigger").
         time.sleep(random.uniform(0.8, 1.4))
-        try:
-            flyout = driver.find_element(By.CSS_SELECTOR, '[class*="bg-flyout"]')
-            btn = None
-            for b in flyout.find_elements(
-                By.CSS_SELECTOR, 'button[class*="bgCtrlBrandRest"]'
-            ):
-                if b.get_attribute("slot"):
-                    continue
-                if not b.is_enabled():
-                    continue
-                btn = b
-                break
-        except Exception as e:
-            self._log(f"[WARNING] Could not find the claim button: {e}")
-            return
+        btn = self._find_claim_control(driver, timeout=10)
 
         if btn is None:
-            self._log("[WARNING] Claim button not found in the flyout.")
+            # Log what the page actually holds: the panel markup is unstable, so
+            # these two counts say whether the panel failed to open at all or
+            # whether it opened with a control we no longer recognise.
+            try:
+                diag = driver.execute_script(
+                    "return document.querySelectorAll('[class*=\"bgCtrlBrand\"]').length"
+                    " + '/' + document.querySelectorAll("
+                    '\'[role="dialog"], [class*="bg-flyout"]\').length;'
+                )
+            except Exception:
+                diag = "?"
+            self._log(
+                "[WARNING] Claim button not found after opening the claim tile "
+                f"(brand controls/panels on page: {diag})."
+            )
             return
         try:
             human.click_element(btn, scroll_into_view=True)

--- a/src/dailytasks/runner.py
+++ b/src/dailytasks/runner.py
@@ -81,6 +81,15 @@ class DailySet:
         self.dashboard_variant = dashboard_variant
         # Filled in on each `perform_daily_set` call after the driver is ready.
         self.cards = None
+        # Entry URL of the new dashboard's "visual search streak" mission, read
+        # during perform_daily_set. The api passes it to the visual search so
+        # the search starts from the link that credits the mission.
+        self.visual_search_url = None
+        # That mission's progress as (done, total) before this run, plus the
+        # new-dashboard handler that read it, so the api can re-read the
+        # progress after the search to check Rewards actually counted it.
+        self.visual_search_progress = None
+        self._new_handler = None
         # Aggregated card counts from the most recent perform_daily_set call,
         # so the caller (api) can record `newly` completed cards in the stats
         # layer without changing this method's bool return contract.
@@ -481,13 +490,42 @@ class DailySet:
             from .new_dashboard import NewDashboardDailySet
 
             handler = NewDashboardDailySet(logger=self.logger)
+            self._new_handler = handler
             result = handler.perform(driver, human, stop_event=stop_event)
             # Surface the new-dashboard run's counts for the stats layer so
             # per-account statistics stay accurate on migrated accounts.
             self.last_totals = dict(handler.last_totals)
+            if handler.visual_search_url:
+                self.visual_search_url = handler.visual_search_url
+            self.visual_search_progress = handler.visual_search_progress
             return result
 
         return self._perform_legacy(driver, human, stop_event=stop_event)
+
+    def read_visual_search_progress(self, driver):
+        """
+        Re-read the new dashboard's "visual search streak" progress.
+
+        Returns:
+            tuple: (done, total), or None on the legacy dashboard, when the
+                mission isn't offered, or when this account hasn't run a
+                new-dashboard pass in this session.
+        """
+        handler = self._new_handler
+
+        if handler is None:
+            # The daily-set pass may not have run this session (already done
+            # today, or "Daily tasks only" skipped it). Build a handler on
+            # demand — except for accounts pinned to the legacy dashboard,
+            # which has no such mission and would just cost a page load.
+            if (self.dashboard_variant or "auto") == "legacy":
+                return None
+
+            from .new_dashboard import NewDashboardDailySet
+
+            handler = NewDashboardDailySet(logger=self.logger)
+
+        return handler.read_visual_search_progress(driver)
 
     def _detect_variant(self, driver):
         """

--- a/src/search/engine.py
+++ b/src/search/engine.py
@@ -11,6 +11,49 @@ from selenium.webdriver.common.by import By
 from ..utils import human_typing
 from ..emulator import HumanBehavior
 
+# Rewards' "visual search streak" mission credits a search only when it starts
+# from the mission's own link: the Bing homepage carrying its promo code. The
+# dashboard handler reads that link off the payload each run; this is the
+# fallback for when it can't (mission not offered, legacy dashboard, daily-set
+# pass skipped).
+REWARDS_VISUAL_SEARCH_URL = (
+    "https://www.bing.com/?features=vsstreak,vstooltip&form=ML2XES"
+)
+
+# Entry points for the "search by image" widget, tried in order. The homepage
+# only injects the camera button through a lazy fragment, and some flights ship
+# no fragment at all, while the Images vertical always renders it server-side.
+VISUAL_SEARCH_URLS = (
+    REWARDS_VISUAL_SEARCH_URL,
+    "https://www.bing.com",
+    "https://www.bing.com/images",
+)
+
+# Selectors for the camera button, from the most to the least specific.
+VISUAL_SEARCH_BUTTON_LOCATORS = (
+    (By.ID, "sb_sbi"),
+    (By.CSS_SELECTOR, "#sbiarea [role='button']"),
+    (By.ID, "sbi_b"),
+)
+
+# The upload flyout itself. #sb_fileinput sits in the DOM whether or not the
+# flyout is open, and a file sent to it while it is closed goes nowhere, so this
+# is what tells us the camera click actually landed.
+VISUAL_SEARCH_PANEL_SELECTOR = "#sb_sbipane, [class*='sbipane']"
+
+# Selectors for the hidden file input of the upload flyout.
+VISUAL_SEARCH_INPUT_LOCATORS = (
+    (By.ID, "sb_fileinput"),
+    (By.CSS_SELECTOR, "input.fileinput[type='file']"),
+    (By.CSS_SELECTOR, "input[type='file'][accept*='image']"),
+)
+
+# URL fragments Bing redirects to once an uploaded image has been searched.
+# Depending on what the image matches, results land either on the image detail
+# page (view=detailv2&iss=sbi...) or on a web SERP for the detected entity
+# (/search?q=...&bcid=...&FORM=SBIIRP), hence several markers.
+VISUAL_SEARCH_RESULT_URL_MARKERS = ("form=sbi", "iss=sbi", "bcid=", "view=detailv2")
+
 
 class SearchEngine:
     """
@@ -290,7 +333,366 @@ class SearchEngine:
 
         return successful
 
-    def perform_visual_search(self, driver, image_path, stop_event=None):
+    def _find_visual_search_element(
+        self,
+        driver,
+        locators,
+        timeout,
+        poll_interval,
+        require_displayed=False,
+        stop_event=None,
+    ):
+        """
+        Poll the page until one of the given locators matches an element.
+
+        Bing renames the ids of its "search by image" widget from time to time,
+        so every step tries a few known selectors instead of a single one.
+
+        Args:
+            driver (WebDriver): An instance of Selenium WebDriver to control the browser.
+            locators (tuple): Tuples of (By, selector) to try, in order of preference.
+            timeout (float): How long to keep polling, in seconds.
+            poll_interval (float): Delay between two polling rounds, in seconds.
+            require_displayed (bool): Whether the element must be visible and enabled.
+                Hidden file inputs still accept send_keys, so this stays False for them.
+            stop_event (threading.Event, optional): When set, polling gives up at
+                once instead of running to the timeout.
+
+        Returns:
+            WebElement: The first matching element, or None if the timeout
+                expired or Stop was requested.
+        """
+
+        deadline = time.monotonic() + timeout
+
+        while True:
+            if stop_event is not None and stop_event.is_set():
+                return None
+
+            for by, selector in locators:
+                try:
+                    element = driver.find_element(by, selector)
+
+                    if require_displayed and not (
+                        element.is_displayed() and element.is_enabled()
+                    ):
+                        continue
+
+                    return element
+
+                except WebDriverException:
+                    continue
+
+            if time.monotonic() >= deadline:
+                return None
+
+            time.sleep(poll_interval)
+
+    def _attempt_visual_search(
+        self, driver, human, url, image_path, poll_interval, stop_event=None
+    ):
+        """
+        Run one full search-by-image attempt from a single entry page.
+
+        Returns:
+            str: "done" when the results were reached, "stopped" on Stop,
+                "no widget" when the page never offered a usable camera button
+                or upload field, and "no results" when the image was uploaded
+                but nothing came back — the case worth retrying elsewhere.
+        """
+        if stop_event is not None and stop_event.is_set():
+            return "stopped"
+
+        driver.get(url)
+        start_url = driver.current_url
+
+        time.sleep(random.uniform(1, 4))
+
+        button = self._find_visual_search_element(
+            driver,
+            VISUAL_SEARCH_BUTTON_LOCATORS,
+            timeout=15,
+            poll_interval=poll_interval,
+            require_displayed=True,
+            stop_event=stop_event,
+        )
+
+        if stop_event is not None and stop_event.is_set():
+            return "stopped"
+
+        if button is None:
+            self._log(f"[WARNING] No visual search button on {url}.")
+            return "no widget"
+
+        human.click_element(button)
+
+        time.sleep(random.uniform(1, 3))
+
+        if not self._open_upload_panel(
+            driver, human, button, poll_interval, stop_event
+        ):
+            self._log(f"[WARNING] Upload flyout stayed closed on {url}.")
+            return "stopped" if self._stopped(stop_event) else "no widget"
+
+        upload_input = self._find_visual_search_element(
+            driver,
+            VISUAL_SEARCH_INPUT_LOCATORS,
+            timeout=15,
+            poll_interval=poll_interval,
+            stop_event=stop_event,
+        )
+
+        if upload_input is None:
+            self._log(f"[WARNING] No image upload field on {url}.")
+            return "stopped" if self._stopped(stop_event) else "no widget"
+
+        time.sleep(random.uniform(1, 4))
+
+        # Send the file path to the hidden type="file" input element
+        upload_input.send_keys(image_path)
+
+        if self._wait_for_visual_search_results(
+            driver,
+            start_url,
+            timeout=45,
+            poll_interval=poll_interval,
+            stop_event=stop_event,
+        ):
+            return "done"
+
+        if self._stopped(stop_event):
+            return "stopped"
+
+        self._log(
+            f"[WARNING] Uploaded from {url} but no results came back "
+            f"({self._page_state(driver)})."
+        )
+        return "no results"
+
+    def _stopped(self, stop_event):
+        """Whether Stop was requested."""
+        return stop_event is not None and stop_event.is_set()
+
+    def _open_upload_panel(self, driver, human, button, poll_interval, stop_event=None):
+        """
+        Make sure the camera click actually opened the upload flyout.
+
+        A pointer click can land on an overlay (Bing shows a coach mark on the
+        Rewards mission entry page) and the file input stays inert, which used
+        to surface much later as an unexplained "no results" timeout. Retry the
+        click through JS, which ignores whatever is on top, then with Escape
+        first to dismiss it.
+
+        Returns:
+            bool: True when the flyout is open, or when this build of Bing has
+                no flyout element at all (unknown markup — don't block on it).
+                False when the flyout exists but stayed closed.
+        """
+        for attempt in range(3):
+            if stop_event is not None and stop_event.is_set():
+                return False
+
+            try:
+                panels = driver.find_elements(
+                    By.CSS_SELECTOR, VISUAL_SEARCH_PANEL_SELECTOR
+                )
+            except WebDriverException:
+                panels = []
+
+            if not panels:
+                self._log(
+                    "[INFO] No upload flyout found on this page; uploading anyway."
+                )
+                return True
+
+            if any(panel.is_displayed() for panel in panels):
+                return True
+
+            if attempt == 0:
+                self._log("[INFO] Upload flyout didn't open. Clicking again.")
+                try:
+                    driver.execute_script("arguments[0].click();", button)
+                except WebDriverException:
+                    pass
+            elif attempt == 1:
+                try:
+                    driver.switch_to.active_element.send_keys(Keys.ESCAPE)
+                    human.click_element(button)
+                except WebDriverException:
+                    pass
+
+            time.sleep(poll_interval + random.uniform(0.5, 1.5))
+
+        return False
+
+    def _wait_for_visual_search_results(
+        self, driver, start_url, timeout, poll_interval, stop_event=None
+    ):
+        """
+        Wait until the uploaded image actually lands on a visual search result page.
+
+        Bing may render the results in the current tab or open them in a new
+        one, so every window is checked and the driver is left on whichever one
+        holds the results.
+
+        Args:
+            driver (WebDriver): An instance of Selenium WebDriver to control the browser.
+            start_url (str): The URL the upload was started from.
+            timeout (float): How long to keep polling, in seconds.
+            poll_interval (float): Delay between two polling rounds, in seconds.
+            stop_event (threading.Event, optional): When set, polling gives up at
+                once instead of running to the timeout.
+
+        Returns:
+            bool: True if the results page was reached, False if the timeout
+                expired or Stop was requested.
+        """
+
+        deadline = time.monotonic() + timeout
+        origin = None
+
+        try:
+            origin = driver.current_window_handle
+        except WebDriverException:
+            pass
+
+        while True:
+            if stop_event is not None and stop_event.is_set():
+                return False
+
+            if self._is_results_url(self._current_url(driver), start_url):
+                return True
+
+            # Results opened in another tab: adopt it and carry on there.
+            try:
+                handles = driver.window_handles
+            except WebDriverException:
+                handles = []
+
+            for handle in handles:
+                if handle == origin:
+                    continue
+                try:
+                    driver.switch_to.window(handle)
+                except WebDriverException:
+                    continue
+                if self._is_results_url(self._current_url(driver), start_url):
+                    self._log("Visual search results opened in a new tab.")
+                    return True
+
+            if origin is not None and handles:
+                try:
+                    driver.switch_to.window(origin)
+                except WebDriverException:
+                    pass
+
+            if time.monotonic() >= deadline:
+                return False
+
+            time.sleep(poll_interval)
+
+    def _current_url(self, driver):
+        """Return the driver's current URL, or "" when it can't be read."""
+        try:
+            return driver.current_url or ""
+        except WebDriverException:
+            return ""
+
+    def _is_results_url(self, url, start_url):
+        """Whether `url` is a visual search result page and not the entry page."""
+        return url != start_url and any(
+            marker in url.lower() for marker in VISUAL_SEARCH_RESULT_URL_MARKERS
+        )
+
+    def _page_state(self, driver):
+        """
+        One-line snapshot of where the browser ended up, for failure logs.
+
+        Reports the tab count, the page title and what the upload flyout itself
+        is showing — an error Bing puts in the flyout ("we couldn't process this
+        image") is the one thing that explains an upload going nowhere.
+        """
+        try:
+            tabs = len(driver.window_handles)
+        except WebDriverException:
+            tabs = "?"
+
+        try:
+            title = (driver.title or "")[:60]
+        except WebDriverException:
+            title = "?"
+
+        try:
+            panel = driver.execute_script(
+                "var p = document.querySelector(arguments[0]);"
+                "return p ? (p.innerText || '').replace(/\\s+/g, ' ').trim().slice(0, 120)"
+                " : null;",
+                VISUAL_SEARCH_PANEL_SELECTOR,
+            )
+        except WebDriverException:
+            panel = "?"
+
+        return f"tabs={tabs}, title={title!r}, flyout says {panel!r}"
+
+    def _search_surface(self, driver):
+        """Return the FORM code of the current page, or its path as a fallback."""
+        try:
+            current_url = driver.current_url or ""
+        except WebDriverException:
+            return "URL unknown"
+
+        for part in current_url.split("?", 1)[-1].split("&"):
+            if part.upper().startswith("FORM="):
+                return part
+        return urlparse(current_url).path or "no FORM code"
+
+    def _log_visual_search_failure(self, driver, step, error=None, stop_event=None):
+        """
+        Log a visual search failure with the step that broke, for debugging.
+
+        Selenium timeouts carry an empty message and a raw msedgedriver
+        stacktrace, so the step name and the current URL are what make the
+        failure readable in the logs.
+
+        Args:
+            driver (WebDriver): An instance of Selenium WebDriver to control the browser.
+            step (str): A short description of the step that failed.
+            error (Exception, optional): The exception that was raised, if any.
+            stop_event (threading.Event, optional): When set, the step didn't
+                fail — it was cancelled — so say that instead.
+
+        Returns:
+            bool: Always False, so callers can `return self._log_visual_search_failure(...)`.
+        """
+
+        if stop_event is not None and stop_event.is_set():
+            self._log("Visual search stopped because Stop was requested.")
+            return False
+
+        try:
+            current_url = driver.current_url
+        except WebDriverException:
+            current_url = "unknown"
+
+        if error is None:
+            reason = "timed out"
+        else:
+            short_error = str(error).split("\n")[0][:80].strip()
+            reason = (
+                f"{type(error).__name__}: {short_error}"
+                if short_error
+                else type(error).__name__
+            )
+
+        self._log(
+            f"[ERROR] Visual search failed while {step} ({reason}). URL: {current_url}"
+        )
+
+        return False
+
+    def perform_visual_search(
+        self, driver, image_path, stop_event=None, entry_url=None
+    ):
         """
         Perform a visual search on Bing using an image file.
 
@@ -298,59 +700,67 @@ class SearchEngine:
             driver (WebDriver): An instance of Selenium WebDriver to control the browser.
             image_path (str): The path to the image file to use for the visual search.
             stop_event (threading.Event, optional): If provided and set, the search will be cancelled.
+            entry_url (str, optional): Page to start from, tried before the
+                defaults. Used for the Rewards mission link read off the
+                dashboard, which is what makes the search credit the streak.
 
         Returns:
             bool: True if the visual search was successful, False otherwise.
         """
-        from selenium.webdriver.support import expected_conditions as EC
-        from selenium.webdriver.support.ui import WebDriverWait
-
         from ..config import APP_DIR
 
-        # In --onefile environments, aggressive WebDriverWait polling overloads
-        # msedgedriver, causing a GetHandleVerifier crash. This flag switches
-        # the script to a time.sleep + static find_element approach which works.
-        if "config" in APP_DIR:
-            portable_mode = True
-        else:
-            portable_mode = False
+        # In --onefile environments, aggressive polling overloads msedgedriver
+        # and causes a GetHandleVerifier crash, so portable builds look for
+        # elements at a slower pace.
+        portable_mode = "config" in APP_DIR
+        poll_interval = 1.5 if portable_mode else 0.5
 
         if stop_event is not None and stop_event.is_set():
             self._log("Skipping visual search because Stop was requested.")
             return False
 
         human = HumanBehavior(driver, show_cursor=True, mobile=False)
+        step = "opening Bing"
+
+        entry_urls = list(VISUAL_SEARCH_URLS)
+        if entry_url and entry_url not in entry_urls:
+            entry_urls.insert(0, entry_url)
 
         try:
-            driver.get("https://www.bing.com")
-            wait = WebDriverWait(driver, 15)
+            outcome = "no widget"
 
-            time.sleep(random.uniform(1, 4))
-
-            if not portable_mode:
-                visual_search_button = wait.until(
-                    EC.element_to_be_clickable((By.ID, "sb_sbi"))
+            for url in entry_urls:
+                outcome = self._attempt_visual_search(
+                    driver, human, url, image_path, poll_interval, stop_event
                 )
-            else:
-                visual_search_button = driver.find_element(By.ID, "sb_sbi")
-                time.sleep(random.uniform(1, 3))
 
-            human.click_element(visual_search_button)
+                if outcome in ("done", "stopped"):
+                    break
 
-            if not portable_mode:
-                upload_input = wait.until(
-                    EC.presence_of_element_located((By.ID, "sb_fileinput"))
+                if outcome == "no results":
+                    # The upload went nowhere on this surface. bing.com is the
+                    # same uploader as the mission link, so the only retry worth
+                    # the time is the Images vertical.
+                    last = entry_urls[-1]
+                    if url != last:
+                        outcome = self._attempt_visual_search(
+                            driver, human, last, image_path, poll_interval, stop_event
+                        )
+                    break
+
+            if outcome == "stopped":
+                self._log("Visual search stopped because Stop was requested.")
+                return False
+
+            if outcome != "done":
+                step = (
+                    "waiting for the visual search results"
+                    if outcome == "no results"
+                    else "reaching Bing's image upload flyout"
                 )
-            else:
-                upload_input = driver.find_element(By.ID, "sb_fileinput")
-
-            time.sleep(random.uniform(1, 4))
-
-            # Send the file path to the hidden type="file" input element
-            upload_input.send_keys(image_path)
-
-            # Wait until the visual search results ("All") page is rendered
-            wait.until(EC.visibility_of_element_located((By.ID, "b-scopeListItem-web")))
+                return self._log_visual_search_failure(
+                    driver, step, stop_event=stop_event
+                )
 
             time.sleep(random.uniform(4, 8))
 
@@ -366,12 +776,20 @@ class SearchEngine:
                 self._log("Visual search stopped because Stop was requested.")
                 return False
 
-            self._log("Visual search completed successfully.")
+            # Log where the search landed: Bing's FORM code identifies the
+            # surface that credited it (SBIHMP from the homepage, SBIIRP from
+            # the Images vertical, a promo code when started from a Rewards
+            # offer link), which is the first thing to check when the search
+            # runs but the Rewards task stays uncredited.
+            self._log(
+                f"Visual search completed successfully ({self._search_surface(driver)})."
+            )
             return True
 
         except Exception as e:
-            self._log(f"[ERROR] Visual search failed: {e}")
-            return False
+            return self._log_visual_search_failure(
+                driver, step, e, stop_event=stop_event
+            )
 
     def get_next_image_id(self, used_images_list):
         """

--- a/src/search/engine.py
+++ b/src/search/engine.py
@@ -449,6 +449,7 @@ class SearchEngine:
         time.sleep(random.uniform(1, 4))
 
         # Send the file path to the hidden type="file" input element
+        known_tabs = self._tab_snapshot(driver)
         upload_input.send_keys(image_path)
 
         if self._wait_for_visual_search_results(
@@ -457,6 +458,7 @@ class SearchEngine:
             timeout=45,
             poll_interval=poll_interval,
             stop_event=stop_event,
+            known_tabs=known_tabs,
         ):
             return "done"
 
@@ -525,8 +527,38 @@ class SearchEngine:
 
         return False
 
+    def _tab_snapshot(self, driver):
+        """Map each open tab to its current URL, to spot which one moves."""
+        snapshot = {}
+
+        try:
+            origin = driver.current_window_handle
+            handles = driver.window_handles
+        except WebDriverException:
+            return snapshot
+
+        for handle in handles:
+            try:
+                driver.switch_to.window(handle)
+                snapshot[handle] = self._current_url(driver)
+            except WebDriverException:
+                continue
+
+        try:
+            driver.switch_to.window(origin)
+        except WebDriverException:
+            pass
+
+        return snapshot
+
     def _wait_for_visual_search_results(
-        self, driver, start_url, timeout, poll_interval, stop_event=None
+        self,
+        driver,
+        start_url,
+        timeout,
+        poll_interval,
+        stop_event=None,
+        known_tabs=None,
     ):
         """
         Wait until the uploaded image actually lands on a visual search result page.
@@ -542,6 +574,11 @@ class SearchEngine:
             poll_interval (float): Delay between two polling rounds, in seconds.
             stop_event (threading.Event, optional): When set, polling gives up at
                 once instead of running to the timeout.
+            known_tabs (dict, optional): Tab -> URL before the upload. A tab that
+                was already open and hasn't moved since is not our result, even
+                when its URL looks like one (a daily-set activity can leave an
+                image page open); without this the search would report a success
+                it didn't make, and skip the retry that would have made it.
 
         Returns:
             bool: True if the results page was reached, False if the timeout
@@ -576,7 +613,10 @@ class SearchEngine:
                     driver.switch_to.window(handle)
                 except WebDriverException:
                     continue
-                if self._is_results_url(self._current_url(driver), start_url):
+                url = self._current_url(driver)
+                if known_tabs and url == known_tabs.get(handle):
+                    continue
+                if self._is_results_url(url, start_url):
                     self._log("Visual search results opened in a new tab.")
                     return True
 


### PR DESCRIPTION
First of all, sorry for being away for so long. Work has been really busy these
past weeks and I couldn't put any time into the project. I'm back, and I started
with the things that were broken on my side.

## Visual search: first a crash, then a silent no-op

Two problems, one hiding behind the other.

**It crashed on every run.** The log gave me an error with an empty Selenium
message and a raw `msedgedriver` stacktrace:

```
[ERROR] Visual search failed: Message:
Stacktrace:
msedgedriver!GetHandleVerifier [0x7ff7c9a6f005+4ab5]
...
```

That empty `Message:` is what a `WebDriverWait` timeout looks like. We were
waiting for the images-results layout (`#b-scopeListItem-web`) to show up after
the upload, but Bing doesn't end there anymore — an uploaded image now lands on a
web SERP for whatever entity it recognised:

```
https://www.bing.com/search?q=<entity>&bcid=<id>&FORM=SBIHMP
```

and that element isn't visible there. So the upload worked, the search worked,
and we threw it all away 15 seconds later. It only seemed to work on the days
Bing happened to return the images layout instead, which is why it looked
flaky rather than broken.

**Then it stopped crashing and still gave me nothing.** The search ran, Bing
answered with a real search-by-image page, and the "Visual search streak" mission
sat there at `Activity: 0/1`.

Turns out the mission card has its own tracked link behind its "Search now"
button:

```
https://www.bing.com/?features=vsstreak,vstooltip&form=ML2XES
```

Start from a bare `bing.com` and you get `FORM=SBIHMP` — a generic code with none
of the mission's promo context. The search happens, the streak never moves.

### What I changed

- Results are detected from the URL (`form=sbi`, `iss=sbi`, `bcid=`,
  `view=detailv2`, plus the URL actually changing) instead of one DOM node, so
  both layouts count.
- The search now starts from the mission link. I read it off the dashboard
  payload via the `vsstreak` feature flag instead of hardcoding it, so it
  survives Microsoft renaming things. Entry points cascade: mission link →
  `bing.com` → `bing.com/images`. That last one earns its place: the homepage
  injects its camera button through a lazy fragment that some flights don't ship
  at all, while the Images vertical renders it server-side.
- Each step tries a few selectors — `#sb_sbi`, `#sbiarea [role="button"]`,
  `#sbi_b` for the camera, `#sb_fileinput`, `input.fileinput`,
  `input[type=file][accept*=image]` for the upload field.
- Credit is checked instead of assumed. After the search we re-read the mission
  progress (`0/1` → `1/1`), and if Rewards didn't count it, the day stays
  unmarked so the next run retries rather than reporting a success nobody got.
  The card is found by its own artwork (`OMR.VisualSearch.VNext…`,
  `search_visual.svg`) and the progress by its `role="progressbar"` / `0/1`
  counter, so no translated label is involved.
- Failures now say where they failed — step, exception type, current URL — rather
  than handing you an empty Selenium message. Success reports the landing
  surface: `Visual search completed successfully (FORM=SBIHMP)`.
- `WebDriverWait` gave way to a gentler polling loop, which keeps the point of
  the portable-mode workaround without duplicating the lookup code.

## While I was in there

**The claim button had disappeared too.** The claim panel lost its `bg-flyout`
wrapper and the brand styling moved onto a `<div>` inside a react-aria pressable,
so `button[class*="bgCtrlBrandRest"]` matched nothing at all. It now matches the
brand token and clicks the pressable around it, preferring the one wrapping the
coins icon, skipping `slot="close"` / `slot="trigger"` and disabled controls, and
refusing to guess at some other brand CTA outside a dialog — clicking the wrong
button is worse than giving up. The old flyout markup still works.

**Two new toggles: "Force daily tasks" and "Force visual search"**, both off by
default. `status.json` remembers what ran today so the next run skips it, which
left me with no way to redo a task whose saved status I didn't trust — like the
visual search above, marked as done on a day it had also crashed. Side effect:
"Daily tasks only" now honours the saved status too, instead of always re-running
the Daily Set.

**A Windows lock could wipe settings.json.** This one bit me for real today: I
opened the app and every setting was back to default — query counts, hidden
browser, my LLM key, autostart. The file wasn't corrupt, it was sitting right
there as `settings.json.backup`, valid JSON with everything in it.

`_read_json` caught `OSError` alongside the JSON parse errors, and
`PermissionError` is an `OSError`. So a single failed open — Defender, the
indexer, or a scheduled background run writing while the window is open — was
enough to have a perfectly good file moved aside and defaults written over it.
Silently. The toggles above make it more likely, since the run now reads
settings a few more times, but the landmine was already there.

Reads retry now, and a file that can't be opened is left alone: `get_settings`
returns the last values it read successfully and writes nothing. Malformed
content is still quarantined — that file really is beyond saving. Anything doing
read-modify-write goes through `settings_for_update()`, which refuses to hand
over values it couldn't confirm, so a save can never persist defaults over the
real ones. A visible "save failed" beats a silent wipe.

## Testing

Live runs against real Bing for the visual search, on both entry paths and on the
failure paths. The two dashboard fixes were checked against the actual card and
panel markup from my account. The settings fix is covered for a locked file, a
malformed one, and a locked file with nothing cached yet — in each case checking
that the real file survives untouched. `flake8`, `black` and `mypy` are clean.

One thing to keep in mind while reviewing: the streak credit depends on Rewards
attribution, which I can only watch from my own account. That's precisely why the
progress is read back and logged after every search now — if it ever stops
counting, the log will say so instead of the app claiming victory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added independent Settings toggles to rerun Daily Set/More Activities and visual search tasks already marked complete.
  - Visual search supports streak-mission entry points and uses a different image when rerun.
  - Forced tasks run no more than once per session, while genuinely completed items remain skipped.
- **Bug Fixes**
  - Improved visual search reliability across supported page layouts and browser tabs.
  - Progress is verified after searching so only credited searches are recorded as complete.
- **Documentation**
  - Updated the user guide with the new settings and task-completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
