### PR TITLE
Settings: side navigation, one page per account, LLM model picker

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -217,8 +217,8 @@ Both are **off by default**, which keeps the normal behaviour: what already ran 
 
 By default, AutoRewarder draws its searches from a large built-in list of English queries. If you'd prefer searches that look natural in **your own language**, enable **"Generate search terms with AI (LLM)"** in the **Search terms** section of the Settings window and provide your own LLM API key (bring-your-own-key).
 
-- **Provider & model:** Choose OpenAI, Anthropic, or Google Gemini, and optionally a specific model (leave blank to use a sensible default for that provider).
-- **API key:** Paste a key from your chosen provider. It is stored locally in your `settings.json` (plain text) and is only sent to that provider to request queries — no personal data is shared.
+- **Provider & model:** Choose OpenAI, Anthropic, or Google Gemini. Leave the model on **Default** to use a sensible model for that provider, or click the refresh button next to the model field: it asks the provider which models your key can use and lets you pick one from the list, so you can follow new releases without typing anything. **Custom…** still lets you enter a model id by hand.
+- **API key:** Paste a key from your chosen provider — the **Get an API key** link under the field opens the right page (OpenAI Platform, Anthropic Console or Google AI Studio). The key is stored locally in your `settings.json` (plain text) and is only sent to that provider to request queries or list its models — no personal data is shared.
 - **Language:** Leave **`auto`** to follow the language of the computer running AutoRewarder (detected automatically), or type a locale such as `fr-FR`, `it-IT`, or `en-US` to force one.
 
 On each run, AutoRewarder asks the provider for a fresh batch of queries in your language. If generation fails for any reason — no key, an invalid key, an exceeded quota, or no internet — it silently falls back to the built-in list, so your run always completes.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -27,6 +27,8 @@ Welcome! This guide will help you get started with AutoRewarder and explain all 
 - [Autostart & Daily Run Time](#autostart--daily-run-time)
 - [AI-generated search terms (LLM)](#ai-generated-search-terms-llm)
 - [Scheduled runs](#scheduled-runs)
+- [Managing accounts](#managing-accounts)
+- [About](#about)
 - [System Tray & Application Exit](#system-tray--application-exit)
 
 ### Activity
@@ -181,9 +183,11 @@ The visual-search flow is designed to:
 
 ## Understanding the Settings
 
+Open the Settings window with the gear icon in the top-right corner. The left-hand navigation has two parts: **Application** sections (General, Daily tasks, Search terms) and one entry per **account**. Each account page gathers everything about that account — rename, re-run setup, delete, its Rewards dashboard and its scheduled run. Sections you have edited show a marker in the navigation, and the footer counts the pending changes until you click **Save**.
+
 ### Rewards Dashboard
 
-This setting determines which version of the Microsoft Rewards page layout the bot should interact with. You can choose from the following options:
+This per-account setting lives at the top of each account page (**Settings → Accounts → _account_ → Microsoft Rewards**). It determines which version of the Microsoft Rewards page layout the bot should interact with. You can choose from the following options:
 
 - **Auto (detect):** The bot will automatically identify and use the correct dashboard layout for your account.
 - **Legacy:** Forces the bot to use the older Rewards dashboard layout.
@@ -202,7 +206,7 @@ This toggle controls whether you can see Microsoft Edge while searches are happe
 
 ### Force daily tasks & visual search
 
-AutoRewarder records, per account and per day, that the Daily Set and the Visual Search have been done, so a second run of the same day skips them. Two toggles in the **Daily tasks** group of the Settings window let you override that record:
+AutoRewarder records, per account and per day, that the Daily Set and the Visual Search have been done, so a second run of the same day skips them. Two toggles in the **Daily tasks** section of the Settings window let you override that record:
 
 - **Force daily tasks:** runs the Daily Set and More Activities even when today is already marked as done. Cards that are genuinely complete are still skipped by the card-level detection, so a forced run on a real already-done day just confirms the state.
 - **Force visual search:** runs the visual search even when today is already marked as done. A different image is picked each time, so nothing is uploaded twice.
@@ -211,7 +215,7 @@ Both are **off by default**, which keeps the normal behaviour: what already ran 
 
 ### AI-generated search terms (LLM)
 
-By default, AutoRewarder draws its searches from a large built-in list of English queries. If you'd prefer searches that look natural in **your own language**, enable **"Generate search terms with AI (LLM)"** in the Settings window and provide your own LLM API key (bring-your-own-key).
+By default, AutoRewarder draws its searches from a large built-in list of English queries. If you'd prefer searches that look natural in **your own language**, enable **"Generate search terms with AI (LLM)"** in the **Search terms** section of the Settings window and provide your own LLM API key (bring-your-own-key).
 
 - **Provider & model:** Choose OpenAI, Anthropic, or Google Gemini, and optionally a specific model (leave blank to use a sensible default for that provider).
 - **API key:** Paste a key from your chosen provider. It is stored locally in your `settings.json` (plain text) and is only sent to that provider to request queries — no personal data is shared.
@@ -225,7 +229,7 @@ On each run, AutoRewarder asks the provider for a fresh batch of queries in your
 ### Autostart & Daily Run Time
 When enabled, AutoRewarder uses your operating system's native task scheduler (Windows Task Scheduler or Linux systemd) to launch headless runs in the background.
 
-- **Independent Schedules:** You can set a specific **Daily run time** (HH:MM) for each account individually in their respective settings cards.
+- **Independent Schedules:** You can set a specific **Daily run time** (HH:MM) for each account individually on its account page in Settings.
 - **Missed Run Catch-up:** If your computer is turned off or asleep during a scheduled time, the run is not lost. The system will automatically catch up and execute the task a few minutes after your next boot.
 - **Smart Deduplication:** If you manually start a run before a delayed catch-up task fires, AutoRewarder detects this and safely skips the scheduled run to prevent double execution.
 
@@ -233,6 +237,14 @@ To disable automated background runs, turn off **Enable Background Auto-Run** or
 
 > [!TIP]
 > **For Multi-Account Users:** If you have multiple accounts configured, it is **highly recommended to stagger their run times**. Since accounts have independent OS tasks, setting them to the exact same time will launch them at the same time, which spikes RAM/CPU usage and can look suspicious to Microsoft (if from the same IP).
+
+### Managing accounts
+
+Every account has its own page in Settings, listed under **Accounts** in the left-hand navigation (the dot next to a name is green when its schedule is on and amber while its first setup is still pending). From the page header you can **rename** the account, **re-run its setup** (for example after the Edge profile got corrupted) or **delete** it — deleting removes the browser profile, history and daily-set status for good. **Add account** at the bottom of the list starts the setup flow for a new account. Switching the active account is still done from the account picker on the main screen.
+
+### About
+
+The **About** section shows the installed version, lets you **check for updates** on demand, opens the folder where AutoRewarder keeps its data (profiles, `settings.json`, background logs) and links to the GitHub repository.
 
 ### System Tray & Application Exit
 By default, clicking the "X" on the main window sends AutoRewarder to the system tray. This allows the application to remain active for background tasks.
@@ -260,7 +272,7 @@ For background runs (Autostart or CLI mode) where there's no visible window, use
 
 ### Scheduled runs
 
-Each account has its own schedule card in the Settings window. The main schedule toggle turns on automated background runs, but it also controls how your manual GUI runs behave.
+Each account has its own page in the Settings window (pick it under **Accounts** in the left-hand navigation); the **Scheduled run** group sits at the bottom of that page. The main schedule toggle turns on automated background runs, but it also controls how your manual GUI runs behave.
 
 **Standard Schedule**
 Turn on the main Schedule toggle, but leave Advanced scheduling *off*. The bot will run automatically at a random minute, processing the PC and Mobile queries in one go.
@@ -361,17 +373,17 @@ If your issue isn't listed, please open an issue on GitHub.
 - Ensure Microsoft Edge is installed
 - Try restarting the application (Selenium Manager will auto-download driver)
 - Check that Edge version is up to date
-- In **Manage accounts**, choose **Re-run setup** for the affected account
+- In **Settings**, open the affected account under **Accounts** and choose **Re-run setup**
 
 **`session not created: DevToolsActivePort file doesn't exist` / Edge failed to start:**
 - Close AutoRewarder and any Edge windows
 - Open Windows Task Manager and kill all `msedge.exe` processes (and `msedgedriver.exe` if present)
 - Open Edge normally and complete any pending updates at `edge://settings/help`
 - Re-run AutoRewarder
-- If it still fails, use **Manage accounts** -> **Re-run setup** for the account
+- If it still fails, open the account in **Settings** and choose **Re-run setup**
 
 **Application crashes on startup:**
-- In **Manage accounts**, delete or re-run setup for the affected account
+- In **Settings**, open the affected account under **Accounts** and delete it or re-run its setup
 - Verify dependencies: `pip install -r requirements.txt` if running from source
 - Check Windows Event Viewer for error details
 

--- a/gui/index.html
+++ b/gui/index.html
@@ -26,14 +26,6 @@
       </div>
 
       <div class="header-actions">
-        <button id="manageBtn" class="icon-ghost" type="button" aria-label="Manage accounts" title="Manage accounts">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
-            <circle cx="9" cy="7" r="4"></circle>
-            <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
-            <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
-          </svg>
-        </button>
         <button id="settingsBtn" class="icon-ghost" type="button" aria-label="Settings" title="Settings">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="3"></circle>
@@ -186,154 +178,215 @@
   </div>
 
   <!-- ==================== Settings modal ==================== -->
+  <!--
+    Two columns: a side navigation (application sections, then one entry per
+    account, then About) and a pane showing a single panel at a time. Account
+    panels and their nav entries are built in script.js from get_all_schedules().
+  -->
   <div id="settings_modal" class="modal-backdrop" hidden>
-    <div class="modal-box wide" role="dialog" aria-modal="true" aria-labelledby="settings_modal_title">
-      <div class="modal-header">
-        <h3 id="settings_modal_title" class="modal-title">Settings</h3>
-        <button id="settingsModalClose" class="icon-ghost" type="button" aria-label="Close">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="18" y1="6" x2="6" y2="18"></line>
-            <line x1="6" y1="6" x2="18" y2="18"></line>
-          </svg>
-        </button>
-      </div>
-      <div class="modal-body">
+    <div class="modal-box settings-box" role="dialog" aria-modal="true" aria-labelledby="settings_modal_title">
 
-        <section class="settings-group">
-          <div class="settings-group-title">General</div>
-          <label class="settings-row">
-            <div class="settings-row-text">
-              <div class="settings-row-label">Enable Background Auto-Run</div>
-              <div class="settings-row-hint" id="startup_hint">Automatically run AutoRewarder in the background at each account's scheduled time.</div>
-            </div>
-            <span class="toggle-compact">
-              <input type="checkbox" id="startupToggle">
-              <span class="toggle-pill"></span>
-            </span>
-          </label>
-          <label class="settings-row">
-            <div class="settings-row-text">
-              <div class="settings-row-label">Close to tray</div>
-              <div class="settings-row-hint">Clicking X minimizes to the system tray instead of quitting. Takes effect on next launch.</div>
-            </div>
-            <span class="toggle-compact">
-              <input type="checkbox" id="closeToTrayToggle">
-              <span class="toggle-pill"></span>
-            </span>
-          </label>
-        </section>
+      <aside class="settings-nav" id="settings_nav">
+        <h3 id="settings_modal_title" class="settings-nav-title">Settings</h3>
 
-        <section class="settings-group">
-          <div class="settings-group-title">Daily tasks</div>
-          <p class="settings-group-hint">
-            A task that already ran today is skipped on the next run. Turn these on to run it again anyway.
-          </p>
-          <label class="settings-row">
-            <div class="settings-row-text">
-              <div class="settings-row-label">Force daily tasks</div>
-              <div class="settings-row-hint">Run the Daily Set and More Activities even when today is already marked as done. Cards that are genuinely complete are still skipped.</div>
-            </div>
-            <span class="toggle-compact">
-              <input type="checkbox" id="forceDailyToggle">
-              <span class="toggle-pill"></span>
-            </span>
-          </label>
-          <label class="settings-row">
-            <div class="settings-row-text">
-              <div class="settings-row-label">Force visual search</div>
-              <div class="settings-row-hint">Run the visual search even when today is already marked as done. A different image is used each time.</div>
-            </div>
-            <span class="toggle-compact">
-              <input type="checkbox" id="forceVisualToggle">
-              <span class="toggle-pill"></span>
-            </span>
-          </label>
-        </section>
+        <div class="settings-nav-group">
+          <div class="settings-nav-eyebrow">Application</div>
+          <button class="settings-nav-item" type="button" data-panel="general">
+            <svg class="settings-nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+              <line x1="4" y1="21" x2="4" y2="14"></line><line x1="4" y1="10" x2="4" y2="3"></line>
+              <line x1="12" y1="21" x2="12" y2="12"></line><line x1="12" y1="8" x2="12" y2="3"></line>
+              <line x1="20" y1="21" x2="20" y2="16"></line><line x1="20" y1="12" x2="20" y2="3"></line>
+              <line x1="1" y1="14" x2="7" y2="14"></line><line x1="9" y1="8" x2="15" y2="8"></line><line x1="17" y1="16" x2="23" y2="16"></line>
+            </svg>
+            <span class="settings-nav-label">General</span>
+          </button>
+          <button class="settings-nav-item" type="button" data-panel="tasks">
+            <svg class="settings-nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline>
+            </svg>
+            <span class="settings-nav-label">Daily tasks</span>
+          </button>
+          <button class="settings-nav-item" type="button" data-panel="search">
+            <svg class="settings-nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+              <circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+            </svg>
+            <span class="settings-nav-label">Search terms</span>
+          </button>
+        </div>
 
-        <section class="settings-group">
-          <div class="settings-group-title">Search terms</div>
-          <label class="settings-row">
-            <div class="settings-row-text">
-              <div class="settings-row-label">Generate search terms with AI (LLM)</div>
-              <div class="settings-row-hint">Use your own LLM API key to generate fresh queries in your language on each run. Falls back to the built-in list if generation fails.</div>
-            </div>
-            <span class="toggle-compact">
-              <input type="checkbox" id="llmToggle">
-              <span class="toggle-pill"></span>
+        <div class="settings-nav-group">
+          <div class="settings-nav-eyebrow">Accounts</div>
+          <div id="settings_nav_accounts" class="settings-nav-accounts"></div>
+          <button id="settingsAddAccount" class="settings-nav-add" type="button">
+            <span class="settings-nav-add-icon" aria-hidden="true">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+                <line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line>
+              </svg>
             </span>
-          </label>
+            Add account
+          </button>
+        </div>
 
-          <div id="llm_fields" class="llm-fields">
-            <div class="form-grid-2">
-              <div class="form-field">
-                <label for="llmProvider">Provider</label>
-                <select id="llmProvider">
-                  <option value="openai">OpenAI</option>
-                  <option value="anthropic">Anthropic</option>
-                  <option value="gemini">Google Gemini</option>
-                </select>
-              </div>
-              <div class="form-field">
-                <label for="llmModel">Model</label>
-                <input type="text" id="llmModel" placeholder="Default for provider" autocomplete="off" spellcheck="false">
-              </div>
-            </div>
-            <div class="form-grid-2">
-              <div class="form-field">
-                <label for="llmApiKey">API key</label>
-                <input type="password" id="llmApiKey" placeholder="Your own API key" autocomplete="off" spellcheck="false">
-              </div>
-              <div class="form-field">
-                <label for="llmLocale">Language</label>
-                <input type="text" id="llmLocale" placeholder="auto" autocomplete="off" spellcheck="false">
-              </div>
-            </div>
-            <p class="form-hint" id="llm_locale_hint">Leave "auto" to follow your system language, or enter a locale like fr-FR.</p>
-            <p class="form-hint">Your API key is stored locally in settings.json (plain text). Requests only send a prompt asking for queries — no personal data.</p>
+        <div class="settings-nav-group settings-nav-bottom">
+          <button class="settings-nav-item" type="button" data-panel="about">
+            <svg class="settings-nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+              <circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line>
+            </svg>
+            <span class="settings-nav-label">About</span>
+          </button>
+        </div>
+      </aside>
+
+      <section class="settings-pane">
+        <div class="settings-pane-header">
+          <div class="settings-pane-heading">
+            <h3 id="settings_pane_title" class="modal-title">General</h3>
+            <p id="settings_pane_desc" class="settings-pane-desc"></p>
           </div>
-        </section>
+        </div>
 
-        <section class="settings-group">
-          <div class="settings-group-title">Scheduled runs</div>
-          <p class="settings-group-hint">
-            One schedule per account. Each run fires at a random minute inside its window for a natural look.
-          </p>
-          <div id="schedule_accounts_list" class="schedule-accounts-list"></div>
-          <div id="schedule_empty" class="accounts-empty" hidden>
-            No accounts yet. Add one first to schedule a run.
+        <div class="settings-pane-body" id="settings_pane_body">
+
+          <!-- General -->
+          <div class="settings-panel" data-panel="general" data-title="General"
+               data-desc="How AutoRewarder behaves on your machine.">
+            <label class="settings-row">
+              <div class="settings-row-text">
+                <div class="settings-row-label">Background auto-run</div>
+                <div class="settings-row-hint" id="startup_hint">Automatically run AutoRewarder in the background at each account's scheduled time.</div>
+              </div>
+              <span class="toggle-compact">
+                <input type="checkbox" id="startupToggle">
+                <span class="toggle-pill"></span>
+              </span>
+            </label>
+            <label class="settings-row">
+              <div class="settings-row-text">
+                <div class="settings-row-label">Close to tray</div>
+                <div class="settings-row-hint">Clicking X minimizes to the system tray instead of quitting. Takes effect on next launch.</div>
+              </div>
+              <span class="toggle-compact">
+                <input type="checkbox" id="closeToTrayToggle">
+                <span class="toggle-pill"></span>
+              </span>
+            </label>
           </div>
-        </section>
 
-      </div>
-      <div class="modal-footer">
-        <button id="settingsCancel" class="btn-secondary" type="button">Cancel</button>
-        <button id="settingsSave" class="btn-primary" type="button">Save</button>
-      </div>
-    </div>
-  </div>
+          <!-- Daily tasks -->
+          <div class="settings-panel" data-panel="tasks" data-title="Daily tasks"
+               data-desc="A task that already ran today is skipped on the next run. Turn these on to run it again anyway.">
+            <label class="settings-row">
+              <div class="settings-row-text">
+                <div class="settings-row-label">Force daily tasks</div>
+                <div class="settings-row-hint">Run the Daily Set and More Activities even when today is already marked as done. Cards that are genuinely complete are still skipped.</div>
+              </div>
+              <span class="toggle-compact">
+                <input type="checkbox" id="forceDailyToggle">
+                <span class="toggle-pill"></span>
+              </span>
+            </label>
+            <label class="settings-row">
+              <div class="settings-row-text">
+                <div class="settings-row-label">Force visual search</div>
+                <div class="settings-row-hint">Run the visual search even when today is already marked as done. A different image is used each time.</div>
+              </div>
+              <span class="toggle-compact">
+                <input type="checkbox" id="forceVisualToggle">
+                <span class="toggle-pill"></span>
+              </span>
+            </label>
+          </div>
 
-  <!-- ==================== Accounts management modal ==================== -->
-  <div id="accounts_modal" class="modal-backdrop" hidden>
-    <div class="modal-box wide" role="dialog" aria-modal="true" aria-labelledby="accounts_modal_title">
-      <div class="modal-header">
-        <h3 id="accounts_modal_title" class="modal-title">Your accounts</h3>
-        <button id="accountsModalClose" class="icon-ghost" type="button" aria-label="Close">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="18" y1="6" x2="6" y2="18"></line>
-            <line x1="6" y1="6" x2="18" y2="18"></line>
-          </svg>
-        </button>
-      </div>
-      <div class="modal-body">
-        <ul id="accounts_list" class="accounts-list"></ul>
-        <button id="addAccountBtn" class="secondary-btn" type="button">
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <line x1="12" y1="5" x2="12" y2="19"></line>
-            <line x1="5" y1="12" x2="19" y2="12"></line>
-          </svg>
-          Add account
-        </button>
-      </div>
+          <!-- Search terms -->
+          <div class="settings-panel" data-panel="search" data-title="Search terms"
+               data-desc="Where the Bing queries come from on each run.">
+            <label class="settings-row">
+              <div class="settings-row-text">
+                <div class="settings-row-label">Generate search terms with AI (LLM)</div>
+                <div class="settings-row-hint">Use your own LLM API key to generate fresh queries in your language on each run. Falls back to the built-in list if generation fails.</div>
+              </div>
+              <span class="toggle-compact">
+                <input type="checkbox" id="llmToggle">
+                <span class="toggle-pill"></span>
+              </span>
+            </label>
+
+            <div id="llm_fields" class="settings-fields">
+              <div class="form-grid-2">
+                <div class="form-field">
+                  <label for="llmProvider">Provider</label>
+                  <select id="llmProvider">
+                    <option value="openai">OpenAI</option>
+                    <option value="anthropic">Anthropic</option>
+                    <option value="gemini">Google Gemini</option>
+                  </select>
+                </div>
+                <div class="form-field">
+                  <label for="llmModel">Model</label>
+                  <input type="text" id="llmModel" placeholder="Default for provider" autocomplete="off" spellcheck="false">
+                </div>
+              </div>
+              <div class="form-grid-2">
+                <div class="form-field">
+                  <label for="llmApiKey">API key</label>
+                  <div class="input-with-action">
+                    <input type="password" id="llmApiKey" placeholder="Your own API key" autocomplete="off" spellcheck="false">
+                    <button id="llmApiKeyToggle" class="input-action" type="button" aria-label="Show API key" title="Show API key">
+                      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div class="form-field">
+                  <label for="llmLocale">Language</label>
+                  <input type="text" id="llmLocale" placeholder="auto" autocomplete="off" spellcheck="false">
+                </div>
+              </div>
+              <p class="form-hint" id="llm_locale_hint">Leave "auto" to follow your system language, or enter a locale like fr-FR.</p>
+              <p class="form-hint">Your API key is stored locally in settings.json (plain text). Requests only send a prompt asking for queries — no personal data.</p>
+            </div>
+          </div>
+
+          <!-- One panel per account, built by script.js -->
+          <div id="settings_account_panels"></div>
+
+          <!-- About -->
+          <div class="settings-panel" data-panel="about" data-title="About"
+               data-desc="Version, updates and where your data lives.">
+            <div class="about-head">
+              <div class="brand-mark" aria-hidden="true">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M12 2l3 7h7l-5.5 4 2 7.5-6.5-4.5-6.5 4.5 2-7.5L2 9h7z"></path>
+                </svg>
+              </div>
+              <div class="about-head-text">
+                <div class="about-name" id="about_version">AutoRewarder</div>
+                <div class="about-status" id="about_status">Microsoft Rewards automation.</div>
+              </div>
+            </div>
+            <dl class="about-kv">
+              <dt>Data folder</dt>
+              <dd id="about_app_dir" class="about-kv-path">—</dd>
+              <dt>Settings file</dt>
+              <dd>settings.json, in that folder. It holds your LLM API key in plain text.</dd>
+            </dl>
+            <div class="about-actions">
+              <button id="aboutCheckUpdates" class="btn-secondary" type="button">Check for updates</button>
+              <button id="aboutOpenFolder" class="btn-secondary" type="button">Open data folder</button>
+              <button id="aboutGithub" class="btn-secondary" type="button">GitHub</button>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="modal-footer">
+          <span id="settings_dirty" class="settings-dirty">No changes</span>
+          <button id="settingsCancel" class="btn-secondary" type="button">Cancel</button>
+          <button id="settingsSave" class="btn-primary" type="button">Save</button>
+        </div>
+      </section>
+
     </div>
   </div>
 

--- a/gui/index.html
+++ b/gui/index.html
@@ -323,9 +323,24 @@
                 </div>
                 <div class="form-field">
                   <label for="llmModel">Model</label>
-                  <input type="text" id="llmModel" placeholder="Default for provider" autocomplete="off" spellcheck="false">
+                  <div class="field-with-button">
+                    <!-- Options are filled by script.js: default, models loaded
+                         from the provider for this key, then "Custom…". -->
+                    <select id="llmModel">
+                      <option value="">Default for provider</option>
+                      <option value="__custom__">Custom…</option>
+                    </select>
+                    <button id="llmModelRefresh" class="icon-btn" type="button" aria-label="Load the model list from the provider" title="Load the model list from the provider">
+                      <svg viewBox="0 0 24 24" aria-hidden="true"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15A9 9 0 1 1 18 5.3L23 10"></path></svg>
+                    </button>
+                  </div>
                 </div>
               </div>
+              <div class="form-field" id="llm_model_custom_field" hidden>
+                <label for="llmModelCustom">Custom model id</label>
+                <input type="text" id="llmModelCustom" placeholder="e.g. gpt-5.4-nano" autocomplete="off" spellcheck="false">
+              </div>
+              <p class="form-hint" id="llm_model_hint">Load the list to pick a model, or keep the provider default.</p>
               <div class="form-grid-2">
                 <div class="form-field">
                   <label for="llmApiKey">API key</label>
@@ -343,6 +358,7 @@
                   <input type="text" id="llmLocale" placeholder="auto" autocomplete="off" spellcheck="false">
                 </div>
               </div>
+              <p class="form-hint">Get an API key from <a href="#" id="llmKeyLink">your provider</a>.</p>
               <p class="form-hint" id="llm_locale_hint">Leave "auto" to follow your system language, or enter a locale like fr-FR.</p>
               <p class="form-hint">Your API key is stored locally in settings.json (plain text). Requests only send a prompt asking for queries — no personal data.</p>
             </div>

--- a/gui/script.js
+++ b/gui/script.js
@@ -660,6 +660,10 @@ async function prompt_and_create_account() {
 // and the "Discard changes?" prompt on close.
 const settingsDirty = new Set();
 let settingsActivePanel = 'general';
+// False while the modal is loading (or after a failed load): Save is
+// disabled and save_settings() refuses to run, so stale or default field
+// values can never be persisted.
+let settingsLoaded = false;
 let aboutRepoUrl = 'https://github.com/safarsin/AutoRewarder';
 
 function account_panel_id(accountId) {
@@ -743,6 +747,13 @@ function open_settings_modal(panelId) {
   settings_clear_dirty();
   settings_go(initialPanel.startsWith('acc:') ? 'general' : initialPanel);
 
+  // Nothing can be saved until every value below has been loaded into the
+  // fields; otherwise a click during loading would persist stale or default
+  // values.
+  settingsLoaded = false;
+  const saveBtn = document.getElementById('settingsSave');
+  if (saveBtn) saveBtn.disabled = true;
+
   Promise.all([
     pywebview.api.get_all_schedules(),
     pywebview.api.get_launch_on_startup(),
@@ -819,9 +830,14 @@ function open_settings_modal(panelId) {
     // programmatically), so nothing is dirty yet — but clear defensively.
     settings_clear_dirty();
     settings_go(initialPanel);
+    settingsLoaded = true;
+    if (saveBtn) saveBtn.disabled = false;
   }).catch(err => {
     console.error('Failed to load settings:', err);
     show_toast('Could not load settings.', 'error');
+    // The fields hold defaults or stale values: close rather than let the
+    // user edit and save them.
+    close_settings_modal({ force: true });
   });
 
   backdrop.hidden = false;
@@ -1469,6 +1485,10 @@ function make_form_field(labelText, inputType, className, value, opts) {
 // -------------------------------------------------------------------------
 
 async function save_settings() {
+  if (!settingsLoaded) {
+    show_toast('Settings are still loading.', 'warning');
+    return;
+  }
   const panels = Array.from(document.querySelectorAll('#settings_account_panels .settings-account-panel'));
   const closeToTrayWanted = document.getElementById('closeToTrayToggle').checked;
   const startupWanted = document.getElementById('startupToggle').checked;

--- a/gui/script.js
+++ b/gui/script.js
@@ -581,10 +581,10 @@ function render_account_menu() {
     manageBtn.style.color = 'var(--text-muted)';
     manageBtn.innerHTML =
       '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>' +
-      '<span>Manage accounts…</span>';
+      '<span>Account settings…</span>';
     manageBtn.addEventListener('click', () => {
       toggle_account_menu(false);
-      open_accounts_modal();
+      open_settings_modal(currentAccountId ? account_panel_id(currentAccountId) : 'general');
     });
     menu.appendChild(manageBtn);
   }
@@ -648,30 +648,100 @@ async function prompt_and_create_account() {
 }
 
 // =========================================================================
-// Accounts management modal (opens from the header button or dropdown action)
+// Settings modal — side navigation, one panel per section / per account
+//
+// Panel ids: "general", "tasks", "search", "about" (static markup in
+// index.html) and "acc:<account_id>" (built here from get_all_schedules()).
+// The per-account identity header, setup banner and rename / re-run setup /
+// delete actions live in settings.js.
 // =========================================================================
 
-function open_accounts_modal() {
-  const backdrop = document.getElementById('accounts_modal');
-  if (!backdrop) return;
-  backdrop.hidden = false;
-  if (typeof render_accounts_section === 'function') {
-    render_accounts_section(accountsCache);
+// Panel ids with unsaved edits. Drives the nav markers, the footer summary
+// and the "Discard changes?" prompt on close.
+const settingsDirty = new Set();
+let settingsActivePanel = 'general';
+let aboutRepoUrl = 'https://github.com/safarsin/AutoRewarder';
+
+function account_panel_id(accountId) {
+  return 'acc:' + accountId;
+}
+
+function settings_panels() {
+  return Array.from(document.querySelectorAll('#settings_pane_body .settings-panel'));
+}
+
+function settings_nav_items() {
+  return Array.from(document.querySelectorAll('#settings_nav .settings-nav-item'));
+}
+
+function settings_is_open() {
+  const backdrop = document.getElementById('settings_modal');
+  return Boolean(backdrop && !backdrop.hidden);
+}
+
+// Show one panel, highlight its nav entry and update the pane header. Falls
+// back to General when the requested panel no longer exists (deleted account).
+function settings_go(panelId) {
+  const panels = settings_panels();
+  let target = panels.find(p => p.dataset.panel === panelId);
+  if (!target) {
+    target = panels.find(p => p.dataset.panel === 'general');
+    if (!target) return;
+    panelId = 'general';
   }
+  settingsActivePanel = panelId;
+
+  panels.forEach(p => p.classList.toggle('active', p === target));
+  settings_nav_items().forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.panel === panelId);
+  });
+
+  const title = document.getElementById('settings_pane_title');
+  const desc = document.getElementById('settings_pane_desc');
+  if (title) title.textContent = target.dataset.title || '';
+  if (desc) desc.textContent = target.dataset.desc || '';
+
+  const body = document.getElementById('settings_pane_body');
+  if (body) body.scrollTop = 0;
 }
 
-function close_accounts_modal() {
-  const backdrop = document.getElementById('accounts_modal');
-  if (backdrop) backdrop.hidden = true;
+function settings_mark_dirty(panelId) {
+  if (!panelId) return;
+  settingsDirty.add(panelId);
+  settings_refresh_dirty();
 }
 
-// =========================================================================
-// Settings modal (general + scheduled run)
-// =========================================================================
+function settings_clear_dirty() {
+  settingsDirty.clear();
+  settings_refresh_dirty();
+}
 
-function open_settings_modal() {
+function settings_refresh_dirty() {
+  settings_nav_items().forEach(btn => {
+    btn.dataset.dirty = settingsDirty.has(btn.dataset.panel) ? '1' : '0';
+  });
+  const summary = document.getElementById('settings_dirty');
+  if (!summary) return;
+  const n = settingsDirty.size;
+  summary.textContent =
+    n === 0 ? 'No changes' : (n === 1 ? '1 section changed' : `${n} sections changed`);
+  summary.classList.toggle('has-changes', n > 0);
+}
+
+/**
+ * Open the Settings modal. `panelId` selects the section to land on
+ * (e.g. account_panel_id(id) from the account dropdown); anything else —
+ * including the click Event passed by a plain listener — opens General.
+ */
+function open_settings_modal(panelId) {
   const backdrop = document.getElementById('settings_modal');
   if (!backdrop) return;
+  const initialPanel = typeof panelId === 'string' ? panelId : 'general';
+
+  // Static panels can be shown right away; account panels exist only after
+  // the schedules have loaded, so settings_go() runs again below.
+  settings_clear_dirty();
+  settings_go(initialPanel.startsWith('acc:') ? 'general' : initialPanel);
 
   Promise.all([
     pywebview.api.get_all_schedules(),
@@ -679,10 +749,11 @@ function open_settings_modal() {
     pywebview.api.get_close_to_tray(),
     pywebview.api.get_llm_config(),
     pywebview.api.get_force_tasks(),
-  ]).then(([schedules, startup, closeToTray, llmConfig, forceTasks]) => {
-    render_schedule_cards(schedules || []);
+    pywebview.api.get_app_info(),
+  ]).then(([schedules, startup, closeToTray, llmConfig, forceTasks, appInfo]) => {
+    render_account_panels(Array.isArray(schedules) ? schedules : []);
 
-    // Start-with-Windows toggle — disable row on unsupported OS.
+    // Background auto-run toggle — disable row on unsupported OS.
     const startupToggle = document.getElementById('startupToggle');
     const startupRow = startupToggle.closest('.settings-row');
     const startupHint = document.getElementById('startup_hint');
@@ -721,7 +792,10 @@ function open_settings_modal() {
     if (llmToggle) llmToggle.checked = Boolean(cfg.use_llm_queries);
     if (providerSel && cfg.llm_provider) providerSel.value = cfg.llm_provider;
     if (modelInput) modelInput.value = cfg.llm_model || '';
-    if (keyInput) keyInput.value = cfg.llm_api_key || '';
+    if (keyInput) {
+      keyInput.value = cfg.llm_api_key || '';
+      set_api_key_visible(false);
+    }
     if (localeInput) localeInput.value = cfg.search_locale || 'auto';
     if (localeHint) {
       const eff = cfg.effective_locale || 'en-US';
@@ -729,6 +803,13 @@ function open_settings_modal() {
         `Detected language: ${eff}. Leave "auto" to follow your system, or enter a locale like fr-FR.`;
     }
     apply_llm_field_state();
+
+    render_about_panel(appInfo || {});
+
+    // Filling the fields above fired no input/change events (values were set
+    // programmatically), so nothing is dirty yet — but clear defensively.
+    settings_clear_dirty();
+    settings_go(initialPanel);
   }).catch(err => {
     console.error('Failed to load settings:', err);
     show_toast('Could not load settings.', 'error');
@@ -737,9 +818,30 @@ function open_settings_modal() {
   backdrop.hidden = false;
 }
 
-function close_settings_modal() {
+/**
+ * Close the Settings modal. With unsaved edits, asks for confirmation first
+ * unless `opts.force` is true (used right after a successful save). A DOM
+ * Event passed by a plain click listener is ignored.
+ */
+async function close_settings_modal(opts) {
   const backdrop = document.getElementById('settings_modal');
-  if (backdrop) backdrop.hidden = true;
+  if (!backdrop || backdrop.hidden) return;
+
+  const force = Boolean(opts && opts.force === true);
+  if (!force && settingsDirty.size > 0) {
+    const n = settingsDirty.size;
+    const discard = await confirm_modal(
+      'Discard changes?',
+      n === 1
+        ? 'One section has unsaved changes. Close without saving?'
+        : `${n} sections have unsaved changes. Close without saving?`,
+      { confirmLabel: 'Discard' }
+    );
+    if (!discard) return;
+  }
+
+  backdrop.hidden = true;
+  settings_clear_dirty();
 }
 
 // Dim + disable the LLM config fields when the feature is toggled off.
@@ -750,25 +852,92 @@ function apply_llm_field_state() {
   fields.classList.toggle('dim', !(toggle && toggle.checked));
 }
 
-function render_schedule_cards(schedules) {
-  const container = document.getElementById('schedule_accounts_list');
-  const empty = document.getElementById('schedule_empty');
-  if (!container || !empty) return;
+function set_api_key_visible(visible) {
+  const key = document.getElementById('llmApiKey');
+  const btn = document.getElementById('llmApiKeyToggle');
+  if (!key) return;
+  key.type = visible ? 'text' : 'password';
+  if (btn) {
+    const label = visible ? 'Hide API key' : 'Show API key';
+    btn.setAttribute('aria-label', label);
+    btn.title = label;
+  }
+}
 
-  container.innerHTML = '';
+// -------------------------------------------------------------------------
+// Account panels (one nav entry + one panel per account)
+// -------------------------------------------------------------------------
 
-  if (!schedules || schedules.length === 0) {
-    container.hidden = true;
-    empty.hidden = false;
+// Merge a get_all_schedules() item with the cached list_accounts() entry so
+// the identity header knows whether this is the current account.
+function account_view_model(item) {
+  const cached = accountsCache.find(a => a.id === item.id);
+  return {
+    id: item.id,
+    label: item.label,
+    first_setup_done: Boolean(item.first_setup_done),
+    is_current: Boolean(cached && cached.is_current),
+  };
+}
+
+function make_nav_empty() {
+  const el = document.createElement('div');
+  el.className = 'settings-nav-empty';
+  el.textContent = 'No accounts yet';
+  return el;
+}
+
+function render_account_panels(schedules) {
+  const navWrap = document.getElementById('settings_nav_accounts');
+  const panelWrap = document.getElementById('settings_account_panels');
+  if (!navWrap || !panelWrap) return;
+
+  navWrap.innerHTML = '';
+  panelWrap.innerHTML = '';
+
+  if (!schedules.length) {
+    navWrap.appendChild(make_nav_empty());
     return;
   }
-  container.hidden = false;
-  empty.hidden = true;
-
   for (const item of schedules) {
-    const card = build_schedule_card(item);
-    container.appendChild(card);
+    navWrap.appendChild(build_account_nav_item(item));
+    panelWrap.appendChild(build_account_panel(item));
   }
+}
+
+function build_account_nav_item(item) {
+  const acc = account_view_model(item);
+  const sched = item.schedule || {};
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'settings-nav-item';
+  btn.dataset.panel = account_panel_id(acc.id);
+  btn.dataset.id = acc.id;
+
+  btn.appendChild(make_avatar(acc, 'sm'));
+
+  const label = document.createElement('span');
+  label.className = 'settings-nav-label';
+  label.textContent = acc.label;
+  btn.appendChild(label);
+
+  const status = document.createElement('span');
+  status.className = 'settings-nav-status';
+  btn.appendChild(status);
+
+  update_account_nav_status(btn, acc, Boolean(sched.enabled));
+  return btn;
+}
+
+// State dot on a nav entry: amber = setup pending, green = schedule on.
+function update_account_nav_status(btn, acc, scheduleEnabled) {
+  const status = btn.querySelector('.settings-nav-status');
+  if (!status) return;
+  const pending = !acc.first_setup_done;
+  status.classList.toggle('pending', pending);
+  status.classList.toggle('on', !pending && scheduleEnabled);
+  status.title = pending ? 'Setup pending' : (scheduleEnabled ? 'Schedule on' : 'Schedule off');
 }
 
 function format_schedule_summary(item, sched, enabled) {
@@ -785,51 +954,65 @@ function format_schedule_summary(item, sched, enabled) {
   return `${prefix}${time} · PC ${pc} / Mobile ${mobile}`;
 }
 
-function build_schedule_card(item) {
-  const acc = { id: item.id, label: item.label };
+/**
+ * Build the full panel for one account: identity header (+ setup banner),
+ * the Rewards dashboard choice, then the schedule. Field class names are
+ * what save_settings() reads back.
+ */
+function build_account_panel(item) {
+  const acc = account_view_model(item);
   const sched = item.schedule || {};
 
-  const card = document.createElement('div');
-  card.className = 'schedule-card' + (sched.enabled ? '' : ' disabled');
-  card.dataset.id = item.id;
+  const panel = document.createElement('div');
+  panel.className = 'settings-panel settings-account-panel';
+  panel.dataset.panel = account_panel_id(acc.id);
+  panel.dataset.id = acc.id;
+  panel.dataset.title = acc.label;
+  panel.dataset.desc = 'Identity, Rewards dashboard and scheduled run for this account.';
 
-  // Header: accordion trigger (avatar + info + chevron) + enable toggle.
+  panel.appendChild(build_account_identity(acc));
+  if (!acc.first_setup_done) panel.appendChild(build_setup_note(acc));
+
+  // --- Microsoft Rewards: which dashboard this account uses. Applies to
+  // every run, not just scheduled ones, hence its own group. ---
+  const rewards = document.createElement('section');
+  rewards.className = 'settings-group';
+
+  const rewardsTitle = document.createElement('div');
+  rewardsTitle.className = 'settings-group-title';
+  rewardsTitle.textContent = 'Microsoft Rewards';
+  rewards.appendChild(rewardsTitle);
+
+  const DASHBOARD_VARIANTS = ['auto', 'legacy', 'new'];
+  const dashDefault = DASHBOARD_VARIANTS.includes(item.dashboard_variant)
+    ? item.dashboard_variant : 'auto';
+  rewards.appendChild(make_select_field('Dashboard', 'schedule-dashboard', dashDefault, [
+    { value: 'auto', label: 'Auto (detect)' },
+    { value: 'legacy', label: 'Legacy' },
+    { value: 'new', label: 'New' },
+  ]));
+
+  const rewardsHint = document.createElement('p');
+  rewardsHint.className = 'form-hint';
+  rewardsHint.textContent =
+    'Which Microsoft Rewards page this account uses for the Daily Set. Applies to every run, scheduled or not.';
+  rewards.appendChild(rewardsHint);
+  panel.appendChild(rewards);
+
+  // --- Scheduled run ---
+  const schedGroup = document.createElement('section');
+  schedGroup.className = 'settings-group';
+
   const header = document.createElement('div');
-  header.className = 'schedule-card-header';
+  header.className = 'settings-group-header';
 
-  const trigger = document.createElement('button');
-  trigger.type = 'button';
-  trigger.className = 'schedule-card-trigger';
-  trigger.setAttribute('aria-expanded', 'false');
+  const schedTitle = document.createElement('div');
+  schedTitle.className = 'settings-group-title';
+  schedTitle.textContent = 'Scheduled run';
 
-  trigger.appendChild(make_avatar(acc));
-
-  const title = document.createElement('div');
-  title.className = 'schedule-card-title';
-  const name = document.createElement('div');
-  name.className = 'schedule-card-name';
-  name.textContent = acc.label;
-  const status = document.createElement('div');
-  status.className = 'schedule-card-status';
-  status.textContent = format_schedule_summary(item, sched, Boolean(sched.enabled));
-  title.appendChild(name);
-  title.appendChild(status);
-  trigger.appendChild(title);
-
-  const chev = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  chev.setAttribute('class', 'schedule-card-chev');
-  chev.setAttribute('width', '14');
-  chev.setAttribute('height', '14');
-  chev.setAttribute('viewBox', '0 0 24 24');
-  chev.setAttribute('fill', 'none');
-  chev.setAttribute('stroke', 'currentColor');
-  chev.setAttribute('stroke-width', '2');
-  chev.setAttribute('stroke-linecap', 'round');
-  chev.setAttribute('stroke-linejoin', 'round');
-  chev.innerHTML = '<polyline points="6 9 12 15 18 9"></polyline>';
-  trigger.appendChild(chev);
-
-  header.appendChild(trigger);
+  const summary = document.createElement('span');
+  summary.className = 'settings-group-summary';
+  summary.textContent = format_schedule_summary(item, sched, Boolean(sched.enabled));
 
   const toggleWrap = document.createElement('label');
   toggleWrap.className = 'toggle-compact';
@@ -843,24 +1026,29 @@ function build_schedule_card(item) {
   togglePill.className = 'toggle-pill';
   toggleWrap.appendChild(toggleInput);
   toggleWrap.appendChild(togglePill);
+
+  header.appendChild(schedTitle);
+  header.appendChild(summary);
   header.appendChild(toggleWrap);
+  schedGroup.appendChild(header);
 
-  card.appendChild(header);
+  // Fields dim while the schedule is off (same pattern as the LLM block).
+  const fields = document.createElement('div');
+  fields.className = 'settings-fields schedule-fields';
+  if (!toggleInput.checked) fields.classList.add('dim');
 
-  // Body (collapsed by default via CSS).
-  const body = document.createElement('div');
-  body.className = 'schedule-card-body';
-
-  // Dashboard variant row (applies to any run, not just scheduled ones):
-  // which Microsoft Rewards dashboard this account uses for the Daily Set.
-  const DASHBOARD_VARIANTS = ['auto', 'legacy', 'new'];
-  const dashDefault = DASHBOARD_VARIANTS.includes(item.dashboard_variant)
-    ? item.dashboard_variant : 'auto';
-  body.appendChild(make_select_field('Rewards dashboard', 'schedule-dashboard', dashDefault, [
-    { value: 'auto', label: 'Auto (detect)' },
-    { value: 'legacy', label: 'Legacy' },
-    { value: 'new', label: 'New' },
-  ]));
+  // Daily fire time + PC/Mobile counts on one row. The time is when the
+  // OS-level scheduled task triggers for this account — only effective when
+  // Background auto-run is on AND this schedule is enabled.
+  const rowMain = document.createElement('div');
+  rowMain.className = 'form-grid-3';
+  const timeDefault = (sched.run_time && /^\d{2}:\d{2}$/.test(sched.run_time)) ? sched.run_time : '09:00';
+  const pcDefault = sched.queries_pc != null ? sched.queries_pc : 30;
+  const mobileDefault = sched.queries_mobile != null ? sched.queries_mobile : 20;
+  rowMain.appendChild(make_form_field('Daily run time', 'time', 'schedule-run-time', timeDefault, {}));
+  rowMain.appendChild(make_form_field('PC queries', 'number', 'schedule-queries-pc', pcDefault, { min: 0, max: 130 }));
+  rowMain.appendChild(make_form_field('Mobile queries', 'number', 'schedule-queries-mobile', mobileDefault, { min: 0, max: 99 }));
+  fields.appendChild(rowMain);
 
   // Advanced scheduling sub-toggle row.
   const advRow = document.createElement('label');
@@ -880,22 +1068,7 @@ function build_schedule_card(item) {
   advWrap.appendChild(advPill);
   advRow.appendChild(advWrap);
   advRow.appendChild(advLabel);
-  body.appendChild(advRow);
-
-  // PC + Mobile row.
-  const rowPcMobile = document.createElement('div');
-  rowPcMobile.className = 'form-grid-2';
-  const pcDefault = sched.queries_pc != null ? sched.queries_pc : 30;
-  const mobileDefault = sched.queries_mobile != null ? sched.queries_mobile : 20;
-  rowPcMobile.appendChild(make_form_field('PC queries', 'number', 'schedule-queries-pc', pcDefault, { min: 0, max: 130 }));
-  rowPcMobile.appendChild(make_form_field('Mobile queries', 'number', 'schedule-queries-mobile', mobileDefault, { min: 0, max: 99 }));
-  body.appendChild(rowPcMobile);
-
-  // Daily fire time row — when the OS-level scheduled task triggers for
-  // this account. Only effective when the global Start-with-Windows
-  // toggle is on AND this account's schedule is enabled.
-  const timeDefault = (sched.run_time && /^\d{2}:\d{2}$/.test(sched.run_time)) ? sched.run_time : '09:00';
-  body.appendChild(make_form_field('Daily run time', 'time', 'schedule-run-time', timeDefault, {}));
+  fields.appendChild(advRow);
 
   // Duration + qph row (only meaningful when advancedScheduling is on).
   const rowAdv = document.createElement('div');
@@ -905,63 +1078,191 @@ function build_schedule_card(item) {
   rowAdv.appendChild(make_form_field('Run duration (h)', 'number', 'schedule-run-duration', durDefault, { min: 1, max: 24 }));
   rowAdv.appendChild(make_form_field('Queries / hour', 'number', 'schedule-queries-per-hour', qphDefault, { min: 1, max: 99 }));
   if (!advInput.checked) rowAdv.classList.add('dim');
-  body.appendChild(rowAdv);
+  fields.appendChild(rowAdv);
 
-  card.appendChild(body);
+  const schedHint = document.createElement('p');
+  schedHint.className = 'form-hint';
+  schedHint.textContent =
+    'Background runs fire at a random minute after this time and need "Background auto-run" (General) to be on. ' +
+    'Advanced scheduling also paces manual runs started from the main screen.';
+  fields.appendChild(schedHint);
 
-  // Accordion expand/collapse on trigger click — one open at a time.
-  trigger.addEventListener('click', () => {
-    const wasExpanded = card.classList.contains('expanded');
-    const container = document.getElementById('schedule_accounts_list');
-    if (container) {
-      container.querySelectorAll('.schedule-card.expanded').forEach(other => {
-        other.classList.remove('expanded');
-        const otherTrig = other.querySelector('.schedule-card-trigger');
-        if (otherTrig) otherTrig.setAttribute('aria-expanded', 'false');
-      });
-    }
-    if (!wasExpanded) {
-      card.classList.add('expanded');
-      trigger.setAttribute('aria-expanded', 'true');
-      // Bring the freshly-expanded card into view inside its scrollable
-      // container so its body fields aren't clipped when there are many
-      // accounts. Wait for the max-height transition to start so we know
-      // the final layout height.
-      setTimeout(() => {
-        try {
-          card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-        } catch (_) { /* older webview engines */ }
-      }, 240);
-    }
-  });
+  schedGroup.appendChild(fields);
+  panel.appendChild(schedGroup);
 
-  // Live summary refresh whenever a field changes.
+  // Live summary + nav dot refresh whenever a field changes.
   const refreshSummary = () => {
     const liveSched = {
       advancedScheduling: advInput.checked,
-      queries_pc: parseInt(card.querySelector('.schedule-queries-pc').value, 10),
-      queries_mobile: parseInt(card.querySelector('.schedule-queries-mobile').value, 10),
-      runDuration: parseInt(card.querySelector('.schedule-run-duration').value, 10),
-      queriesPerHour: parseInt(card.querySelector('.schedule-queries-per-hour').value, 10),
-      run_time: card.querySelector('.schedule-run-time').value,
+      queries_pc: parseInt(panel.querySelector('.schedule-queries-pc').value, 10),
+      queries_mobile: parseInt(panel.querySelector('.schedule-queries-mobile').value, 10),
+      runDuration: parseInt(panel.querySelector('.schedule-run-duration').value, 10),
+      queriesPerHour: parseInt(panel.querySelector('.schedule-queries-per-hour').value, 10),
+      run_time: panel.querySelector('.schedule-run-time').value,
     };
-    status.textContent = format_schedule_summary(item, liveSched, toggleInput.checked);
+    summary.textContent = format_schedule_summary(item, liveSched, toggleInput.checked);
   };
 
   toggleInput.addEventListener('change', () => {
-    card.classList.toggle('disabled', !toggleInput.checked);
+    fields.classList.toggle('dim', !toggleInput.checked);
+    const navItem = settings_nav_items().find(b => b.dataset.panel === panel.dataset.panel);
+    if (navItem) update_account_nav_status(navItem, acc, toggleInput.checked);
     refreshSummary();
   });
   advInput.addEventListener('change', () => {
     rowAdv.classList.toggle('dim', !advInput.checked);
     refreshSummary();
   });
-  body.querySelectorAll('input[type="number"], input[type="time"]').forEach(f => {
+  fields.querySelectorAll('input[type="number"], input[type="time"]').forEach(f => {
     f.addEventListener('input', refreshSummary);
   });
 
-  return card;
+  return panel;
 }
+
+/**
+ * Called from refresh_account_ui() whenever the account list changes while
+ * Settings is open (rename, delete, create, setup finished, account switch).
+ * Reconciles nav entries and panels in place so unsaved schedule edits on
+ * untouched accounts survive.
+ */
+function sync_settings_accounts() {
+  if (!settings_is_open()) return;
+
+  pywebview.api.get_all_schedules().then(schedules => {
+    const list = Array.isArray(schedules) ? schedules : [];
+    const navWrap = document.getElementById('settings_nav_accounts');
+    const panelWrap = document.getElementById('settings_account_panels');
+    if (!navWrap || !panelWrap) return;
+
+    const known = new Set(list.map(item => item.id));
+
+    // Drop what no longer exists.
+    Array.from(panelWrap.children).forEach(panel => {
+      if (!known.has(panel.dataset.id)) {
+        settingsDirty.delete(panel.dataset.panel);
+        panel.remove();
+      }
+    });
+    Array.from(navWrap.children).forEach(el => {
+      if (el.classList.contains('settings-nav-empty') || !known.has(el.dataset.id)) el.remove();
+    });
+
+    // Add new accounts, refresh the identity of existing ones.
+    for (const item of list) {
+      const panel = Array.from(panelWrap.children).find(p => p.dataset.id === item.id);
+      const navItem = Array.from(navWrap.children).find(b => b.dataset.id === item.id);
+
+      if (!panel || !navItem) {
+        if (panel) panel.remove();
+        if (navItem) navItem.remove();
+        navWrap.appendChild(build_account_nav_item(item));
+        panelWrap.appendChild(build_account_panel(item));
+        continue;
+      }
+
+      const acc = account_view_model(item);
+      panel.dataset.title = acc.label;
+
+      const head = panel.querySelector('.settings-account-head');
+      if (head) head.replaceWith(build_account_identity(acc));
+
+      const note = panel.querySelector('.settings-setup-note');
+      if (acc.first_setup_done && note) note.remove();
+      if (!acc.first_setup_done && !note) {
+        const newHead = panel.querySelector('.settings-account-head');
+        if (newHead) newHead.insertAdjacentElement('afterend', build_setup_note(acc));
+      }
+
+      const label = navItem.querySelector('.settings-nav-label');
+      if (label) label.textContent = acc.label;
+      const avatar = navItem.querySelector('.avatar');
+      if (avatar) avatar.replaceWith(make_avatar(acc, 'sm'));
+      const enabledInput = panel.querySelector('.schedule-enabled');
+      update_account_nav_status(navItem, acc, Boolean(enabledInput && enabledInput.checked));
+    }
+
+    if (!list.length) navWrap.appendChild(make_nav_empty());
+
+    settings_refresh_dirty();
+    // Re-applies the header (label may have changed) or falls back to
+    // General if the active account was just deleted.
+    settings_go(settingsActivePanel);
+  }).catch(err => {
+    console.error('sync_settings_accounts failed:', err);
+  });
+}
+
+// -------------------------------------------------------------------------
+// About panel
+// -------------------------------------------------------------------------
+
+function render_about_panel(info) {
+  const version = document.getElementById('about_version');
+  const dir = document.getElementById('about_app_dir');
+  const status = document.getElementById('about_status');
+  if (version) version.textContent = 'AutoRewarder ' + (info.version || '');
+  if (dir) {
+    dir.textContent = info.app_dir || '—';
+    dir.title = info.app_dir || '';
+  }
+  if (status) {
+    status.className = 'about-status';
+    status.textContent = 'Updates are checked once at launch.';
+  }
+  if (info.repo_url) aboutRepoUrl = String(info.repo_url);
+}
+
+function about_check_updates() {
+  const btn = document.getElementById('aboutCheckUpdates');
+  const status = document.getElementById('about_status');
+  if (!btn || !status) return;
+
+  const originalLabel = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = 'Checking…';
+  status.className = 'about-status';
+  status.textContent = 'Contacting GitHub…';
+
+  const restore = () => {
+    btn.disabled = false;
+    btn.textContent = originalLabel;
+  };
+
+  pywebview.api.check_updates_now().then(result => {
+    const r = result || {};
+    status.textContent = '';
+    if (!r.ok) {
+      status.className = 'about-status warning';
+      status.textContent = 'Could not reach GitHub. Try again later.';
+    } else if (r.update_available) {
+      status.className = 'about-status warning';
+      status.appendChild(document.createTextNode(`Version ${r.latest} is available. `));
+      // Anchor built via createElement so the URL is never parsed as HTML.
+      const a = document.createElement('a');
+      a.href = '#';
+      a.textContent = 'Download';
+      a.addEventListener('click', (e) => {
+        e.preventDefault();
+        pywebview.api.open_link(String(r.url));
+      });
+      status.appendChild(a);
+    } else {
+      status.className = 'about-status ok';
+      status.textContent = `You're up to date (${r.current}).`;
+    }
+    restore();
+  }).catch(err => {
+    console.error('check_updates_now failed:', err);
+    status.className = 'about-status warning';
+    status.textContent = 'Update check failed.';
+    restore();
+  });
+}
+
+// -------------------------------------------------------------------------
+// Form field factories
+// -------------------------------------------------------------------------
 
 function make_select_field(labelText, className, value, options) {
   const wrap = document.createElement('div');
@@ -1006,50 +1307,59 @@ function make_form_field(labelText, inputType, className, value, opts) {
   return wrap;
 }
 
+// -------------------------------------------------------------------------
+// Save
+// -------------------------------------------------------------------------
+
 async function save_settings() {
-  const cards = Array.from(document.querySelectorAll('#schedule_accounts_list .schedule-card'));
+  const panels = Array.from(document.querySelectorAll('#settings_account_panels .settings-account-panel'));
   const closeToTrayWanted = document.getElementById('closeToTrayToggle').checked;
   const startupWanted = document.getElementById('startupToggle').checked;
 
-  // Validate + collect payloads per account.
+  // Validate + collect payloads per account. On a validation error, jump to
+  // the offending account so the toast points at a visible field.
   const payloads = [];
-  for (const card of cards) {
-    const id = card.dataset.id;
-    const enabled = card.querySelector('.schedule-enabled').checked;
-    const advancedScheduling = card.querySelector('.schedule-advanced').checked;
-    const pc = parseInt(card.querySelector('.schedule-queries-pc').value, 10);
-    const mobile = parseInt(card.querySelector('.schedule-queries-mobile').value, 10);
-    const runDuration = parseInt(card.querySelector('.schedule-run-duration').value, 10);
-    const queriesPerHour = parseInt(card.querySelector('.schedule-queries-per-hour').value, 10);
-    const runTime = card.querySelector('.schedule-run-time').value;
-    const dashEl = card.querySelector('.schedule-dashboard');
+  for (const panel of panels) {
+    const id = panel.dataset.id;
+    const enabled = panel.querySelector('.schedule-enabled').checked;
+    const advancedScheduling = panel.querySelector('.schedule-advanced').checked;
+    const pc = parseInt(panel.querySelector('.schedule-queries-pc').value, 10);
+    const mobile = parseInt(panel.querySelector('.schedule-queries-mobile').value, 10);
+    const runDuration = parseInt(panel.querySelector('.schedule-run-duration').value, 10);
+    const queriesPerHour = parseInt(panel.querySelector('.schedule-queries-per-hour').value, 10);
+    const runTime = panel.querySelector('.schedule-run-time').value;
+    const dashEl = panel.querySelector('.schedule-dashboard');
     const dashboardVariant = dashEl && ['auto', 'legacy', 'new'].includes(dashEl.value)
       ? dashEl.value : 'auto';
 
     if (enabled) {
+      const reject = (message) => {
+        settings_go(panel.dataset.panel);
+        show_toast(message, 'warning');
+      };
       if (isNaN(pc) || pc < 0 || pc > 130) {
-        show_toast('PC queries must be between 0 and 130.', 'warning');
+        reject('PC queries must be between 0 and 130.');
         return;
       }
       if (isNaN(mobile) || mobile < 0 || mobile > 99) {
-        show_toast('Mobile queries must be between 0 and 99.', 'warning');
+        reject('Mobile queries must be between 0 and 99.');
         return;
       }
       if ((pc || 0) + (mobile || 0) === 0) {
-        show_toast('Set at least one of PC or Mobile queries above 0.', 'warning');
+        reject('Set at least one of PC or Mobile queries above 0.');
         return;
       }
       if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(runTime || '')) {
-        show_toast('Daily run time must be a valid HH:MM value.', 'warning');
+        reject('Daily run time must be a valid HH:MM value.');
         return;
       }
       if (advancedScheduling) {
         if (isNaN(runDuration) || runDuration < 1 || runDuration > 24) {
-          show_toast('Run duration must be between 1 and 24 hours.', 'warning');
+          reject('Run duration must be between 1 and 24 hours.');
           return;
         }
         if (isNaN(queriesPerHour) || queriesPerHour < 1 || queriesPerHour > 99) {
-          show_toast('Queries per hour must be between 1 and 99.', 'warning');
+          reject('Queries per hour must be between 1 and 99.');
           return;
         }
       }
@@ -1123,7 +1433,8 @@ async function save_settings() {
     } else {
       show_toast('Settings saved.', 'success');
     }
-    close_settings_modal();
+    settings_clear_dirty();
+    close_settings_modal({ force: true });
   } catch (err) {
     console.error('save_settings failed:', err);
     show_toast('Save failed.', 'error');
@@ -1171,10 +1482,8 @@ function refresh_account_ui() {
     // Stats are per-account — refresh the compact card for the new selection.
     refresh_stats_ui();
 
-    // Re-render the accounts management modal list if open.
-    if (typeof render_accounts_section === 'function') {
-      render_accounts_section(accountsCache);
-    }
+    // Keep the Settings modal's account entries in sync if it is open.
+    sync_settings_accounts();
   }).catch(err => {
     console.error('refresh_account_ui failed:', err);
   });
@@ -1275,40 +1584,74 @@ document.addEventListener('DOMContentLoaded', function() {
     if (e.key === 'Escape') toggle_account_menu(false);
   });
 
-  // Header "manage accounts" button.
-  const manageBtn = document.getElementById('manageBtn');
-  if (manageBtn) manageBtn.addEventListener('click', open_accounts_modal);
-
   // Header settings button.
   const settingsBtn = document.getElementById('settingsBtn');
   if (settingsBtn) settingsBtn.addEventListener('click', open_settings_modal);
 
-  // Settings modal close + save.
-  const settingsClose = document.getElementById('settingsModalClose');
-  if (settingsClose) settingsClose.addEventListener('click', close_settings_modal);
+  // Settings navigation (delegated: account entries are built dynamically).
+  const settingsNav = document.getElementById('settings_nav');
+  if (settingsNav) {
+    settingsNav.addEventListener('click', (e) => {
+      const item = e.target.closest('.settings-nav-item');
+      if (item && item.dataset.panel) settings_go(item.dataset.panel);
+    });
+  }
+  const settingsAddAccount = document.getElementById('settingsAddAccount');
+  if (settingsAddAccount) settingsAddAccount.addEventListener('click', prompt_and_create_account);
+
+  // Unsaved-changes tracking: any edit inside a panel marks that panel.
+  const settingsBody = document.getElementById('settings_pane_body');
+  if (settingsBody) {
+    const markFromEvent = (e) => {
+      if (!e.target.matches('input, select, textarea')) return;
+      const panel = e.target.closest('.settings-panel');
+      if (panel) settings_mark_dirty(panel.dataset.panel);
+    };
+    settingsBody.addEventListener('change', markFromEvent);
+    settingsBody.addEventListener('input', markFromEvent);
+  }
+
+  // Settings modal leaves only through Save or Cancel (no close cross, no
+  // click-outside), so a change is never dropped by accident.
   const settingsCancel = document.getElementById('settingsCancel');
-  if (settingsCancel) settingsCancel.addEventListener('click', close_settings_modal);
+  if (settingsCancel) settingsCancel.addEventListener('click', () => close_settings_modal());
   const settingsSave = document.getElementById('settingsSave');
   if (settingsSave) settingsSave.addEventListener('click', save_settings);
+  // Escape behaves like Cancel. Deferred so the generic modal's own Escape
+  // handler (registered below) runs first and cannot cancel the
+  // "Discard changes?" prompt this may open.
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    const appModal = document.getElementById('app_modal');
+    if (appModal && !appModal.hidden) return;
+    if (settings_is_open()) setTimeout(() => close_settings_modal(), 0);
+  });
 
-  // LLM feature toggle dims/undims its config fields live.
+  // LLM feature toggle dims/undims its config fields live; eye button shows
+  // or hides the API key.
   const llmToggle = document.getElementById('llmToggle');
   if (llmToggle) llmToggle.addEventListener('change', apply_llm_field_state);
-  const settingsModal = document.getElementById('settings_modal');
-  if (settingsModal) {
-    settingsModal.addEventListener('click', (e) => {
-      if (e.target === settingsModal) close_settings_modal();
+  const llmKeyToggle = document.getElementById('llmApiKeyToggle');
+  if (llmKeyToggle) {
+    llmKeyToggle.addEventListener('click', () => {
+      const key = document.getElementById('llmApiKey');
+      set_api_key_visible(Boolean(key && key.type === 'password'));
     });
   }
-  // Accounts modal close.
-  const accountsModalClose = document.getElementById('accountsModalClose');
-  if (accountsModalClose) accountsModalClose.addEventListener('click', close_accounts_modal);
-  const accountsModal = document.getElementById('accounts_modal');
-  if (accountsModal) {
-    accountsModal.addEventListener('click', (e) => {
-      if (e.target === accountsModal) close_accounts_modal();
+
+  // About panel actions.
+  const aboutCheck = document.getElementById('aboutCheckUpdates');
+  if (aboutCheck) aboutCheck.addEventListener('click', about_check_updates);
+  const aboutFolder = document.getElementById('aboutOpenFolder');
+  if (aboutFolder) {
+    aboutFolder.addEventListener('click', () => {
+      pywebview.api.open_data_folder().then(ok => {
+        if (!ok) show_toast('Could not open the data folder.', 'error');
+      });
     });
   }
+  const aboutGithub = document.getElementById('aboutGithub');
+  if (aboutGithub) aboutGithub.addEventListener('click', () => pywebview.api.open_link(aboutRepoUrl));
 
   // Generic modal wiring.
   const modalConfirm = document.getElementById('modal_confirm');

--- a/gui/script.js
+++ b/gui/script.js
@@ -785,13 +785,14 @@ function open_settings_modal(panelId) {
     const cfg = llmConfig || {};
     const llmToggle = document.getElementById('llmToggle');
     const providerSel = document.getElementById('llmProvider');
-    const modelInput = document.getElementById('llmModel');
     const keyInput = document.getElementById('llmApiKey');
     const localeInput = document.getElementById('llmLocale');
     const localeHint = document.getElementById('llm_locale_hint');
     if (llmToggle) llmToggle.checked = Boolean(cfg.use_llm_queries);
     if (providerSel && cfg.llm_provider) providerSel.value = cfg.llm_provider;
-    if (modelInput) modelInput.value = cfg.llm_model || '';
+    llmDefaultModels = cfg.default_models || {};
+    llm_render_model_options(cfg.llm_model || '');
+    llm_update_key_link();
     if (keyInput) {
       keyInput.value = cfg.llm_api_key || '';
       set_api_key_visible(false);
@@ -803,6 +804,14 @@ function open_settings_modal(panelId) {
         `Detected language: ${eff}. Leave "auto" to follow your system, or enter a locale like fr-FR.`;
     }
     apply_llm_field_state();
+    // Fill the model picker once per session when the feature is usable;
+    // the refresh button re-fetches on demand.
+    if (cfg.use_llm_queries && cfg.llm_api_key) {
+      if (llmModelCache[llm_provider()]) llm_set_model_hint(llm_loaded_hint(), false);
+      else llm_load_models();
+    } else {
+      llm_set_model_hint(LLM_MODEL_HINT_IDLE, false);
+    }
 
     render_about_panel(appInfo || {});
 
@@ -861,6 +870,154 @@ function set_api_key_visible(visible) {
     const label = visible ? 'Hide API key' : 'Show API key';
     btn.setAttribute('aria-label', label);
     btn.title = label;
+  }
+}
+
+// -------------------------------------------------------------------------
+// Search terms: key portals + model picker
+// -------------------------------------------------------------------------
+
+const LLM_PROVIDERS = {
+  openai:    { label: 'OpenAI',        keyLabel: 'the OpenAI Platform',   keyUrl: 'https://platform.openai.com/api-keys' },
+  anthropic: { label: 'Anthropic',     keyLabel: 'the Anthropic Console', keyUrl: 'https://console.anthropic.com/settings/keys' },
+  gemini:    { label: 'Google Gemini', keyLabel: 'Google AI Studio',      keyUrl: 'https://aistudio.google.com/app/apikey' },
+};
+const LLM_CUSTOM_MODEL = '__custom__';
+const LLM_MODEL_HINT_IDLE = 'Load the list to pick a model, or keep the provider default.';
+
+// Models fetched this session, per provider: switching providers back and
+// forth refills the picker without another network call.
+let llmModelCache = {};
+// Provider -> default model id (from get_llm_config); labels the blank choice.
+let llmDefaultModels = {};
+
+function llm_provider() {
+  const sel = document.getElementById('llmProvider');
+  const value = sel ? sel.value : 'openai';
+  return LLM_PROVIDERS[value] ? value : 'openai';
+}
+
+function llm_update_key_link() {
+  const link = document.getElementById('llmKeyLink');
+  if (!link) return;
+  const info = LLM_PROVIDERS[llm_provider()];
+  link.textContent = info.keyLabel;
+  link.dataset.url = info.keyUrl;
+}
+
+// The model id as it will be saved; '' means the provider default.
+function llm_model_value() {
+  const sel = document.getElementById('llmModel');
+  if (!sel) return '';
+  if (sel.value === LLM_CUSTOM_MODEL) {
+    const custom = document.getElementById('llmModelCustom');
+    return custom ? custom.value.trim() : '';
+  }
+  return sel.value;
+}
+
+function llm_apply_custom_state() {
+  const sel = document.getElementById('llmModel');
+  const field = document.getElementById('llm_model_custom_field');
+  if (!sel || !field) return;
+  field.hidden = sel.value !== LLM_CUSTOM_MODEL;
+}
+
+/**
+ * Rebuild the model picker: provider default, the models loaded for the
+ * current provider, the configured id when it is not among them, then
+ * "Custom…" for a hand-typed id.
+ */
+function llm_render_model_options(selectedId) {
+  const sel = document.getElementById('llmModel');
+  if (!sel) return;
+  const provider = llm_provider();
+  const wanted = (selectedId || '').trim();
+  const loaded = llmModelCache[provider] || [];
+
+  sel.innerHTML = '';
+  const add = (value, label, title) => {
+    const o = document.createElement('option');
+    o.value = value;
+    o.textContent = label;
+    if (title) o.title = title;
+    sel.appendChild(o);
+  };
+  const def = llmDefaultModels[provider];
+  add('', def ? `Default (${def})` : 'Default for provider');
+  loaded.forEach(m => add(m.id, m.label || m.id, m.id));
+  if (wanted && !loaded.some(m => m.id === wanted)) add(wanted, wanted, wanted);
+  add(LLM_CUSTOM_MODEL, 'Custom…');
+
+  sel.value = wanted;
+  llm_apply_custom_state();
+}
+
+function llm_set_model_hint(text, isWarning) {
+  const hint = document.getElementById('llm_model_hint');
+  if (!hint) return;
+  hint.textContent = text;
+  hint.classList.toggle('warning', Boolean(isWarning));
+}
+
+function llm_loaded_hint() {
+  const n = (llmModelCache[llm_provider()] || []).length;
+  return `${n} model${n === 1 ? '' : 's'} available for this key.`;
+}
+
+// Ask the provider which models this key can use, then refill the picker.
+function llm_load_models() {
+  const provider = llm_provider();
+  const keyInput = document.getElementById('llmApiKey');
+  const key = keyInput ? keyInput.value.trim() : '';
+  const btn = document.getElementById('llmModelRefresh');
+  if (!key) {
+    llm_set_model_hint('Enter an API key to load the model list.', true);
+    return;
+  }
+  if (btn) { btn.disabled = true; btn.classList.add('busy'); }
+  llm_set_model_hint(`Loading models from ${LLM_PROVIDERS[provider].label}…`, false);
+
+  const done = () => {
+    if (btn) { btn.disabled = false; btn.classList.remove('busy'); }
+  };
+  pywebview.api.list_llm_models(provider, key).then(result => {
+    const r = result || {};
+    if (r.ok && Array.isArray(r.models)) {
+      llmModelCache[provider] = r.models;
+      // Only touch the picker if the user is still on that provider.
+      if (llm_provider() === provider) {
+        llm_render_model_options(llm_model_value());
+        llm_set_model_hint(llm_loaded_hint(), false);
+      }
+    } else if (llm_provider() === provider) {
+      llm_set_model_hint(r.error || 'Could not load the model list.', true);
+    }
+    done();
+  }).catch(err => {
+    console.error('list_llm_models failed:', err);
+    if (llm_provider() === provider) llm_set_model_hint('Could not load the model list.', true);
+    done();
+  });
+}
+
+function llm_on_provider_change() {
+  const provider = llm_provider();
+  const current = llm_model_value();
+  const loaded = llmModelCache[provider] || [];
+  // A model id rarely survives a provider switch: keep it only if the new
+  // provider's list knows it, otherwise fall back to that provider's default.
+  llm_render_model_options(loaded.some(m => m.id === current) ? current : '');
+  llm_update_key_link();
+  llm_set_model_hint(loaded.length ? llm_loaded_hint() : LLM_MODEL_HINT_IDLE, false);
+}
+
+function llm_on_toggle_change() {
+  apply_llm_field_state();
+  const toggle = document.getElementById('llmToggle');
+  const keyInput = document.getElementById('llmApiKey');
+  if (toggle && toggle.checked && keyInput && keyInput.value.trim() && !llmModelCache[llm_provider()]) {
+    llm_load_models();
   }
 }
 
@@ -1399,8 +1556,8 @@ async function save_settings() {
     const llmToggleEl = document.getElementById('llmToggle');
     await pywebview.api.set_llm_config(
       Boolean(llmToggleEl && llmToggleEl.checked),
-      document.getElementById('llmProvider').value,
-      document.getElementById('llmModel').value,
+      llm_provider(),
+      llm_model_value(),
       document.getElementById('llmApiKey').value,
       document.getElementById('llmLocale').value
     );
@@ -1627,15 +1784,47 @@ document.addEventListener('DOMContentLoaded', function() {
     if (settings_is_open()) setTimeout(() => close_settings_modal(), 0);
   });
 
-  // LLM feature toggle dims/undims its config fields live; eye button shows
-  // or hides the API key.
+  // LLM feature toggle dims/undims its config fields live (and fills the
+  // model picker the first time it is switched on); eye button shows or
+  // hides the API key.
   const llmToggle = document.getElementById('llmToggle');
-  if (llmToggle) llmToggle.addEventListener('change', apply_llm_field_state);
+  if (llmToggle) llmToggle.addEventListener('change', llm_on_toggle_change);
   const llmKeyToggle = document.getElementById('llmApiKeyToggle');
   if (llmKeyToggle) {
     llmKeyToggle.addEventListener('click', () => {
       const key = document.getElementById('llmApiKey');
       set_api_key_visible(Boolean(key && key.type === 'password'));
+    });
+  }
+
+  // Model picker: provider switch refills it, "Custom…" reveals a text
+  // field, the refresh button and a freshly pasted key load the list, and
+  // the key-portal link opens the provider's page in the browser.
+  const llmProviderSel = document.getElementById('llmProvider');
+  if (llmProviderSel) llmProviderSel.addEventListener('change', llm_on_provider_change);
+  const llmModelSel = document.getElementById('llmModel');
+  if (llmModelSel) {
+    llmModelSel.addEventListener('change', () => {
+      llm_apply_custom_state();
+      if (llmModelSel.value === LLM_CUSTOM_MODEL) {
+        const custom = document.getElementById('llmModelCustom');
+        if (custom) custom.focus();
+      }
+    });
+  }
+  const llmRefresh = document.getElementById('llmModelRefresh');
+  if (llmRefresh) llmRefresh.addEventListener('click', llm_load_models);
+  const llmKeyInput = document.getElementById('llmApiKey');
+  if (llmKeyInput) {
+    llmKeyInput.addEventListener('change', () => {
+      if (llmKeyInput.value.trim()) llm_load_models();
+    });
+  }
+  const llmKeyLink = document.getElementById('llmKeyLink');
+  if (llmKeyLink) {
+    llmKeyLink.addEventListener('click', (e) => {
+      e.preventDefault();
+      if (llmKeyLink.dataset.url) pywebview.api.open_link(llmKeyLink.dataset.url);
     });
   }
 

--- a/gui/settings.js
+++ b/gui/settings.js
@@ -1,6 +1,8 @@
 // =========================================================================
-// Accounts management modal — list rendering + per-account actions.
-// The generic toast / modal / avatar helpers live in script.js.
+// Settings › Accounts — per-account panel helpers: identity header, setup
+// banner and the rename / re-run setup / delete actions. The panels
+// themselves are assembled in script.js (build_account_panel), where the
+// generic toast / modal / avatar helpers also live.
 // =========================================================================
 
 const ACCOUNT_ICONS = {
@@ -9,104 +11,124 @@ const ACCOUNT_ICONS = {
   trash:  '<svg viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/></svg>',
 };
 
-function render_accounts_section(accounts) {
-  const list = document.getElementById('accounts_list');
-  if (!list) return;
+/**
+ * Header of an account panel: large avatar, label, state line and the
+ * action buttons. `acc` = {id, label, first_setup_done, is_current}.
+ */
+function build_account_identity(acc) {
+  const head = document.createElement('div');
+  head.className = 'settings-account-head';
 
-  list.innerHTML = '';
+  head.appendChild(make_avatar(acc, 'lg'));
 
-  if (!accounts || accounts.length === 0) {
-    const empty = document.createElement('li');
-    empty.className = 'accounts-empty';
-    empty.textContent = 'No accounts yet. Click “Add account” to create your first one.';
-    list.appendChild(empty);
-    return;
-  }
+  const text = document.createElement('div');
+  text.className = 'settings-account-text';
 
-  for (const acc of accounts) {
-    const item = document.createElement('li');
-    item.className = 'account-item' + (acc.is_current ? ' current' : '');
+  const name = document.createElement('div');
+  name.className = 'settings-account-name';
+  name.textContent = acc.label;
 
-    item.appendChild(make_avatar(acc));
+  const meta = document.createElement('div');
+  meta.className = 'settings-account-meta';
+  const state = document.createElement('span');
+  state.className = acc.first_setup_done ? 'ok' : 'pending';
+  state.textContent = acc.first_setup_done ? 'Ready' : 'Setup pending';
+  meta.appendChild(state);
+  if (acc.is_current) meta.appendChild(document.createTextNode(' · Current account'));
 
-    const info = document.createElement('div');
-    info.className = 'account-item-info';
-    const name = document.createElement('div');
-    name.className = 'account-item-name';
-    name.textContent = acc.label;
-    const meta = document.createElement('div');
-    meta.className = 'account-item-meta';
-    meta.textContent =
-      (acc.is_current ? 'Current · ' : '') +
-      (acc.first_setup_done ? 'Ready' : 'Setup pending');
-    info.appendChild(name);
-    info.appendChild(meta);
-    item.appendChild(info);
+  text.appendChild(name);
+  text.appendChild(meta);
+  head.appendChild(text);
 
-    const actions = document.createElement('div');
-    actions.className = 'account-actions';
-
-    const renameBtn = document.createElement('button');
-    renameBtn.className = 'icon-btn';
-    renameBtn.title = 'Rename';
-    renameBtn.setAttribute('aria-label', 'Rename');
-    renameBtn.innerHTML = ACCOUNT_ICONS.rename;
-    renameBtn.addEventListener('click', async () => {
-      const newLabel = await prompt_modal(
-        'Rename account',
-        `Enter a new name for "${acc.label}".`,
-        acc.label,
-        { confirmLabel: 'Rename' }
-      );
-      if (newLabel === null) return;
-      const trimmed = String(newLabel).trim();
-      if (!trimmed) return;
-      pywebview.api.rename_account(acc.id, trimmed).then(ok => {
-        if (!ok) show_toast('Rename failed.', 'error');
-        else show_toast(`Renamed to "${trimmed}".`, 'success');
-      });
-    });
-
-    const resetupBtn = document.createElement('button');
-    resetupBtn.className = 'icon-btn';
-    resetupBtn.title = acc.first_setup_done ? 'Re-run setup' : 'Run setup';
-    resetupBtn.setAttribute('aria-label', resetupBtn.title);
-    resetupBtn.innerHTML = ACCOUNT_ICONS.setup;
-    resetupBtn.addEventListener('click', () => {
-      show_toast(`Opening browser to set up "${acc.label}"…`, 'info', { duration: 6000 });
-      pywebview.api.rerun_setup(acc.id).then(ok => {
-        if (!ok) show_toast('Setup could not be started.', 'error');
-      });
-    });
-
-    const deleteBtn = document.createElement('button');
-    deleteBtn.className = 'icon-btn danger';
-    deleteBtn.title = 'Delete';
-    deleteBtn.setAttribute('aria-label', 'Delete');
-    deleteBtn.innerHTML = ACCOUNT_ICONS.trash;
-    deleteBtn.addEventListener('click', async () => {
-      const confirmed = await confirm_modal(
-        `Delete "${acc.label}"?`,
-        'This removes its browser profile, history, and daily-set status. This cannot be undone.',
-        { confirmLabel: 'Delete', danger: true }
-      );
-      if (!confirmed) return;
-      pywebview.api.delete_account(acc.id).then(success => {
-        if (!success) show_toast('Delete failed.', 'error');
-        else show_toast(`"${acc.label}" deleted.`, 'success');
-      });
-    });
-
-    actions.appendChild(resetupBtn);
-    actions.appendChild(renameBtn);
-    actions.appendChild(deleteBtn);
-    item.appendChild(actions);
-
-    list.appendChild(item);
-  }
+  head.appendChild(build_account_actions(acc));
+  return head;
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  const addBtn = document.getElementById('addAccountBtn');
-  if (addBtn) addBtn.addEventListener('click', prompt_and_create_account);
-});
+function build_account_actions(acc) {
+  const actions = document.createElement('div');
+  actions.className = 'account-actions';
+
+  const resetupBtn = document.createElement('button');
+  resetupBtn.type = 'button';
+  resetupBtn.className = 'icon-btn';
+  resetupBtn.title = acc.first_setup_done ? 'Re-run setup' : 'Run setup';
+  resetupBtn.setAttribute('aria-label', resetupBtn.title);
+  resetupBtn.innerHTML = ACCOUNT_ICONS.setup;
+  resetupBtn.addEventListener('click', () => run_account_setup(acc));
+
+  const renameBtn = document.createElement('button');
+  renameBtn.type = 'button';
+  renameBtn.className = 'icon-btn';
+  renameBtn.title = 'Rename';
+  renameBtn.setAttribute('aria-label', 'Rename');
+  renameBtn.innerHTML = ACCOUNT_ICONS.rename;
+  renameBtn.addEventListener('click', async () => {
+    const newLabel = await prompt_modal(
+      'Rename account',
+      `Enter a new name for "${acc.label}".`,
+      acc.label,
+      { confirmLabel: 'Rename' }
+    );
+    if (newLabel === null) return;
+    const trimmed = String(newLabel).trim();
+    if (!trimmed) return;
+    pywebview.api.rename_account(acc.id, trimmed).then(ok => {
+      if (!ok) show_toast('Rename failed.', 'error');
+      else show_toast(`Renamed to "${trimmed}".`, 'success');
+    });
+  });
+
+  const deleteBtn = document.createElement('button');
+  deleteBtn.type = 'button';
+  deleteBtn.className = 'icon-btn danger';
+  deleteBtn.title = 'Delete';
+  deleteBtn.setAttribute('aria-label', 'Delete');
+  deleteBtn.innerHTML = ACCOUNT_ICONS.trash;
+  deleteBtn.addEventListener('click', async () => {
+    const confirmed = await confirm_modal(
+      `Delete "${acc.label}"?`,
+      'This removes its browser profile, history, and daily-set status. This cannot be undone.',
+      { confirmLabel: 'Delete', danger: true }
+    );
+    if (!confirmed) return;
+    pywebview.api.delete_account(acc.id).then(success => {
+      if (!success) show_toast('Delete failed.', 'error');
+      else show_toast(`"${acc.label}" deleted.`, 'success');
+    });
+  });
+
+  actions.appendChild(resetupBtn);
+  actions.appendChild(renameBtn);
+  actions.appendChild(deleteBtn);
+  return actions;
+}
+
+/** Banner shown on an account whose first setup has not been completed. */
+function build_setup_note(acc) {
+  const note = document.createElement('div');
+  note.className = 'settings-setup-note';
+
+  const text = document.createElement('p');
+  const strong = document.createElement('b');
+  strong.textContent = "This account isn't set up yet.";
+  text.appendChild(strong);
+  text.appendChild(document.createTextNode(' Sign in once in the browser so runs can start.'));
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'btn-primary small';
+  btn.textContent = 'Run setup';
+  btn.addEventListener('click', () => run_account_setup(acc));
+
+  note.appendChild(text);
+  note.appendChild(btn);
+  return note;
+}
+
+// Opens the browser for First Setup; the promise resolves once setup ends.
+function run_account_setup(acc) {
+  show_toast(`Opening browser to set up "${acc.label}"…`, 'info', { duration: 6000 });
+  pywebview.api.rerun_setup(acc.id).then(ok => {
+    if (!ok) show_toast('Setup was not completed.', 'error');
+  });
+}

--- a/gui/styles.css
+++ b/gui/styles.css
@@ -1067,125 +1067,243 @@ input[type="number"]:focus {
   border-color: var(--border);
 }
 .btn-secondary:hover { color: var(--text); border-color: var(--text-muted); }
+.btn-secondary:disabled { opacity: 0.6; cursor: default; }
 
 /* =========================================================================
-   Accounts list inside management modal
+   Settings modal — side navigation + one panel at a time
    ========================================================================= */
 
-.accounts-list {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 12px 0;
+/* Nearly the full 680x840 window: 172px of navigation on the left, and a
+   content pane whose inner width matches the old single-column modal, so
+   the existing row / field styles below apply unchanged. */
+.modal-box.settings-box {
+  width: 632px;
+  max-width: calc(100% - 48px);
+  height: 760px;
+  max-height: 90vh;
+  display: grid;
+  grid-template-columns: 172px minmax(0, 1fr);
+}
+
+/* --- Navigation column --- */
+
+.settings-nav {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  max-height: 300px;
+  gap: 14px;
+  padding: 14px 10px 10px 10px;
+  background-color: rgba(0, 0, 0, 0.18);
+  border-right: 1px solid var(--border-soft);
   overflow-y: auto;
+  min-height: 0;
 }
 
-.accounts-empty {
-  padding: 20px 0;
-  text-align: center;
+.settings-nav-title {
+  margin: 0;
+  padding: 0 8px 2px 8px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.settings-nav-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.settings-nav-bottom { margin-top: auto; }
+
+.settings-nav-eyebrow {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
   color: var(--text-dim);
-  font-size: 13px;
+  padding: 0 8px;
+  margin-bottom: 6px;
 }
 
-.account-item {
+.settings-nav-accounts {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.settings-nav-item {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 12px;
-  background-color: var(--surface-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  transition: border-color 0.15s;
-}
-
-.account-item:hover { border-color: var(--accent); }
-
-.account-item.current {
-  border-color: var(--accent);
-  background-color: var(--accent-soft);
-}
-
-.account-item-info { flex: 1; min-width: 0; }
-
-.account-item-name {
+  gap: 9px;
+  width: 100%;
+  padding: 7px 8px;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: var(--text-muted);
   font-size: 13px;
-  font-weight: 500;
+  text-align: left;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.settings-nav-item:hover {
+  background-color: var(--surface-2);
   color: var(--text);
+}
+
+.settings-nav-item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.settings-nav-item.active {
+  background-color: var(--accent-soft);
+  color: var(--text);
+}
+
+.settings-nav-item.active .settings-nav-icon { color: var(--accent); }
+
+/* Unsaved-changes marker: a thin accent bar on the left edge of the entry. */
+.settings-nav-item::before {
+  content: "";
+  position: absolute;
+  left: 1px;
+  top: 50%;
+  width: 3px;
+  height: 14px;
+  margin-top: -7px;
+  border-radius: 2px;
+  background-color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.settings-nav-item[data-dirty="1"]::before { opacity: 1; }
+
+.settings-nav-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.settings-nav-item .avatar-sm { flex-shrink: 0; }
+
+.settings-nav-label {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.account-item-meta {
-  font-size: 11px;
+/* Per-account state dot: schedule on (green), setup pending (amber), off. */
+.settings-nav-status {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--surface-3);
+  flex-shrink: 0;
+}
+
+.settings-nav-status.on      { background-color: var(--success); }
+.settings-nav-status.pending { background-color: var(--warning); }
+
+.settings-nav-empty {
+  padding: 6px 8px;
+  font-size: 12px;
   color: var(--text-dim);
 }
 
-.account-actions { display: flex; gap: 4px; flex-shrink: 0; }
-
-.icon-btn {
-  background-color: transparent;
-  color: var(--text-muted);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 0;
-  width: 28px;
-  height: 28px;
-  display: inline-flex;
+.settings-nav-add {
+  display: flex;
   align-items: center;
-  justify-content: center;
+  gap: 9px;
+  width: 100%;
+  margin-top: 4px;
+  padding: 6px 8px;
+  background: transparent;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  color: var(--text-dim);
+  font-size: 12.5px;
+  text-align: left;
   transition: color 0.15s, border-color 0.15s;
 }
 
-.icon-btn svg {
-  width: 14px;
-  height: 14px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+.settings-nav-add:hover {
+  color: var(--text);
+  border-color: var(--text-muted);
 }
 
-.icon-btn:hover {
-  color: var(--accent);
-  border-color: var(--accent);
-}
-
-.icon-btn.danger:hover {
-  color: var(--danger);
-  border-color: var(--danger);
-}
-
-.secondary-btn {
+.settings-nav-add-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  width: 100%;
-  padding: 10px 14px;
-  background-color: transparent;
-  color: var(--accent);
-  border: 1px dashed var(--border);
-  border-radius: var(--radius-md);
-  font-size: 13px;
-  font-weight: 500;
-  transition: background-color 0.15s, border-color 0.15s;
+  background-color: var(--surface-2);
+  flex-shrink: 0;
 }
 
-.secondary-btn:hover {
-  background-color: var(--accent-soft);
-  border-color: var(--accent);
-  border-style: solid;
+/* --- Content pane --- */
+
+.settings-pane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
 }
 
-/* =========================================================================
-   Settings modal — grouped rows + schedule form
-   ========================================================================= */
+.settings-pane-header {
+  padding: 16px 22px 10px 22px;
+  flex-shrink: 0;
+}
+
+.settings-pane-heading { min-width: 0; }
+
+.settings-pane-heading .modal-title { font-size: 16px; }
+
+.settings-pane-desc {
+  margin: 3px 0 0 0;
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.45;
+}
+
+.settings-pane-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px 22px 18px 22px;
+}
+
+.settings-panel { display: none; }
+.settings-panel.active { display: block; }
+
+/* Footer summary of pending changes (left side of Save / Cancel). */
+.settings-dirty {
+  margin-right: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.settings-dirty::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--surface-3);
+}
+
+.settings-dirty.has-changes { color: var(--text-muted); }
+.settings-dirty.has-changes::before { background-color: var(--accent); }
+
+/* --- Groups and rows --- */
 
 .settings-group {
   padding-bottom: 14px;
@@ -1208,14 +1326,36 @@ input[type="number"]:focus {
   margin-bottom: 10px;
 }
 
+/* Group title + live summary + enable toggle on one line. */
+.settings-group-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.settings-group-header .settings-group-title { margin-bottom: 0; }
+
+.settings-group-summary {
+  margin-left: auto;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
 .settings-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 6px 0;
+  padding: 9px 0;
   cursor: pointer;
 }
+
+.settings-row + .settings-row { border-top: 1px solid var(--border-soft); }
 
 .settings-row-text { flex: 1; min-width: 0; }
 
@@ -1267,127 +1407,122 @@ input[type="number"]:focus {
   line-height: 1.45;
 }
 
-/* Per-account schedule list (one card per account) */
-
-.schedule-accounts-list {
+/* A block of form fields that dims when its parent toggle is off
+   (LLM config, an account's schedule). */
+.settings-fields {
+  margin-top: 10px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  /* No internal cap or scroll — the parent .modal-body handles overflow,
-     so we avoid the nested-scroll situation that was clipping cards. */
+  gap: 8px;
+  transition: opacity 0.15s;
 }
 
-.schedule-card {
-  background-color: var(--surface-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  display: flex;
-  flex-direction: column;
-  /* CRITICAL: keep cards at their natural height. Without this, the parent
-     `.schedule-accounts-list` (a flex column with capped max-height) shrinks
-     every card proportionally to fit, which chops the headers in half and
-     clips the inputs of the expanded card. */
-  flex-shrink: 0;
-  overflow: hidden;
-  transition: border-color 0.15s, background-color 0.15s;
+.settings-fields.dim {
+  opacity: 0.45;
+  pointer-events: none;
 }
 
-.schedule-card-header {
+.settings-fields .form-hint { margin: 2px 0 0 0; }
+
+.settings-group-header + .settings-fields { margin-top: 0; }
+
+/* --- Account panel: identity header + setup banner --- */
+
+.settings-account-head {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 12px;
+  gap: 12px;
+  padding: 4px 0 12px 0;
 }
 
-.schedule-card-title {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
+.settings-account-text { flex: 1; min-width: 0; }
 
-.schedule-card-name {
-  font-size: 13px;
-  font-weight: 500;
+.settings-account-name {
+  font-size: 15px;
+  font-weight: 600;
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.schedule-card-status {
-  font-size: 11px;
+.settings-account-meta {
+  font-size: 12px;
   color: var(--text-dim);
-  /* Keep the live summary on a single line with an ellipsis when it
-     gets long (e.g. "PC 30 / Mobile 20 · 3h @ 10/h · Setup pending"). */
-  overflow: hidden;
-  text-overflow: ellipsis;
+  margin-top: 1px;
+}
+
+.settings-account-meta .ok      { color: var(--success); }
+.settings-account-meta .pending { color: var(--warning); }
+
+.account-actions { display: flex; gap: 4px; flex-shrink: 0; }
+
+.icon-btn {
+  background-color: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.icon-btn svg {
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.icon-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.icon-btn.danger:hover {
+  color: var(--danger);
+  border-color: var(--danger);
+}
+
+.settings-setup-note {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  background-color: var(--warning-soft);
+  border: 1px solid rgba(251, 191, 36, 0.25);
+}
+
+.settings-setup-note p {
+  flex: 1;
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.settings-setup-note p b {
+  color: var(--text);
+  font-weight: 500;
+}
+
+.btn-primary.small {
+  padding: 6px 11px;
+  font-size: 12.5px;
+  border-radius: var(--radius-sm);
   white-space: nowrap;
 }
 
-.schedule-card.expanded .schedule-card-status {
-  color: var(--text-muted);
-}
-
-.schedule-card-body {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  max-height: 0;
-  opacity: 0;
-  padding: 0 12px;
-  overflow: hidden;
-  transition: max-height 0.22s ease, opacity 0.18s ease, padding 0.22s ease;
-  pointer-events: none;
-}
-
-.schedule-card.expanded .schedule-card-body {
-  max-height: 320px;
-  opacity: 1;
-  /* Padding top + a thin separator give a clear break between the header
-     (avatar / status / toggle) and the form fields, so the body doesn't
-     look glued to the header when the card is open. */
-  padding: 12px;
-  border-top: 1px solid var(--border-soft);
-  pointer-events: auto;
-}
-
-.schedule-card.disabled.expanded .schedule-card-body {
-  opacity: 0.55;
-}
-
-.schedule-card.expanded { border-color: var(--accent); }
-
-.schedule-card-trigger {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  background: transparent;
-  border: none;
-  padding: 0;
-  color: inherit;
-  cursor: pointer;
-  text-align: left;
-  font: inherit;
-}
-
-.schedule-card-trigger:hover { background: transparent; box-shadow: none; }
-
-.schedule-card-chev {
-  color: var(--text-dim);
-  flex-shrink: 0;
-  transition: transform 0.2s, color 0.15s;
-}
-
-.schedule-card.expanded .schedule-card-chev {
-  transform: rotate(180deg);
-  color: var(--accent);
-}
-
-/* Advanced scheduling sub-toggle + fields inside the accordion body */
+/* Advanced scheduling sub-toggle + fields inside an account panel */
 .sched-adv-row {
   display: inline-flex;
   align-items: center;
@@ -1410,9 +1545,17 @@ input[type="number"]:focus {
   pointer-events: none;
 }
 
+/* --- Form fields --- */
+
 .form-grid-2 {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.form-grid-3 {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr 1fr;
   gap: 8px;
 }
 
@@ -1443,7 +1586,7 @@ input[type="number"]:focus {
 .form-field select {
   width: 100%;
   padding: 8px 10px;
-  background-color: var(--surface-1);
+  background-color: var(--surface-2);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text);
@@ -1454,7 +1597,6 @@ input[type="number"]:focus {
 }
 
 .form-field input[type="number"] { text-align: left; }
-
 
 .form-field input:focus,
 .form-field select:focus {
@@ -1471,6 +1613,32 @@ input[type="number"]:focus {
   background-position: right 10px center;
 }
 
+/* Text input with a trailing icon button (show / hide the API key). */
+.input-with-action { position: relative; }
+
+.input-with-action input { padding-right: 34px !important; }
+
+.input-action {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 4px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-dim);
+  display: inline-flex;
+  transition: color 0.15s;
+}
+
+.input-action:hover { color: var(--text); }
+
+.input-action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+}
+
 .form-hint {
   margin: 10px 0 0 0;
   font-size: 11.5px;
@@ -1478,28 +1646,76 @@ input[type="number"]:focus {
   line-height: 1.45;
 }
 
-/* LLM search-term generation fields (Settings modal) */
-
-.llm-fields {
-  margin-top: 10px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  transition: opacity 0.15s;
-}
-
-.llm-fields.dim {
-  opacity: 0.45;
-  pointer-events: none;
-}
-
-.llm-fields .form-hint {
-  margin: 2px 0 0 0;
-}
-
 .row-disabled {
   opacity: 0.5;
   pointer-events: none;
+}
+
+/* --- About panel --- */
+
+.about-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 6px 0 12px 0;
+}
+
+.about-head-text { min-width: 0; }
+
+.about-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.about-status {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 1px;
+}
+
+.about-status.ok      { color: var(--success); }
+.about-status.warning { color: var(--warning); }
+
+.about-status a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.about-status a:hover { text-decoration: underline; }
+
+.about-kv {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr);
+  gap: 6px 14px;
+  margin: 0;
+  padding: 10px 0 14px 0;
+  border-top: 1px solid var(--border-soft);
+  border-bottom: 1px solid var(--border-soft);
+  font-size: 12.5px;
+}
+
+.about-kv dt { color: var(--text-dim); }
+
+.about-kv dd {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.45;
+  user-select: text;
+}
+
+/* The data-folder path stays on one line (full value in the tooltip). */
+.about-kv dd.about-kv-path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.about-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
 }
 
 /* =========================================================================

--- a/gui/styles.css
+++ b/gui/styles.css
@@ -1058,6 +1058,8 @@ input[type="number"]:focus {
   border-color: var(--accent);
 }
 .btn-primary:hover { background-color: var(--accent-hover); border-color: var(--accent-hover); }
+.btn-primary:disabled { opacity: 0.6; cursor: default; }
+.btn-primary:disabled:hover { background-color: var(--accent); border-color: var(--accent); }
 .btn-primary.danger { background-color: var(--danger); border-color: var(--danger); color: white; }
 .btn-primary.danger:hover { background-color: #e05555; border-color: #e05555; }
 

--- a/gui/styles.css
+++ b/gui/styles.css
@@ -1613,6 +1613,28 @@ input[type="number"]:focus {
   background-position: right 10px center;
 }
 
+/* A select with a side icon button (model picker + "load models"). */
+.field-with-button {
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+}
+
+.field-with-button select { flex: 1; min-width: 0; }
+
+.field-with-button .icon-btn {
+  width: 34px;
+  height: auto;
+  flex-shrink: 0;
+}
+
+.icon-btn:disabled { opacity: 0.6; cursor: default; }
+
+.icon-btn.busy svg { animation: spin 0.8s linear infinite; }
+
+/* .form-field sets display:flex, which would beat the UA [hidden] rule. */
+.form-field[hidden] { display: none; }
+
 /* Text input with a trailing icon button (show / hide the API key). */
 .input-with-action { position: relative; }
 
@@ -1645,6 +1667,15 @@ input[type="number"]:focus {
   color: var(--text-dim);
   line-height: 1.45;
 }
+
+.form-hint.warning { color: var(--warning); }
+
+.form-hint a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.form-hint a:hover { text-decoration: underline; }
 
 .row-disabled {
   opacity: 0.5;

--- a/src/api.py
+++ b/src/api.py
@@ -18,6 +18,7 @@ import webbrowser
 # display-layer requirements.
 
 from .config import (
+    APP_DIR,
     GUI_DIR,
     REPO,
     CURRENT_VERSION,
@@ -382,6 +383,65 @@ class AutoRewarderAPI:
     def open_link(self, url):
         """Open a URL in the system default browser."""
         webbrowser.open(url)
+
+    # ------------------------------------------------------------------
+    # Exposed to JS: Settings > About
+    # ------------------------------------------------------------------
+
+    def get_app_info(self):
+        """Return version and storage details for the About panel."""
+        return {
+            "version": CURRENT_VERSION,
+            "app_dir": APP_DIR,
+            "repo_url": f"https://github.com/{REPO}",
+            "platform": platform.system(),
+        }
+
+    def open_data_folder(self):
+        """
+        Open the app data folder (profiles, settings.json, logs) in the OS
+        file manager.
+
+        Returns:
+            bool: True if the file manager was launched, False otherwise.
+        """
+        try:
+            if sys.platform == "win32":
+                os.startfile(APP_DIR)
+            else:
+                subprocess.Popen(
+                    ["xdg-open", APP_DIR],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            return True
+        except Exception as e:
+            self.log(f"[ERROR] Could not open the data folder: {e}")
+            return False
+
+    def check_updates_now(self):
+        """
+        Check GitHub for a newer release on demand (About panel button).
+
+        Unlike the launch-time check, the result is returned to the caller
+        instead of being pushed into the activity log.
+
+        Returns:
+            dict: {ok, update_available, latest, current, url}. `ok` is False
+                when GitHub could not be reached; `latest` is None then.
+        """
+        try:
+            needs_update, latest = check_for_updates(logger=self.log)
+        except Exception as e:
+            self.log(f"[ERROR] Error checking for updates: {e}")
+            needs_update, latest = False, None
+        return {
+            "ok": latest is not None,
+            "update_available": bool(needs_update and latest),
+            "latest": latest,
+            "current": CURRENT_VERSION,
+            "url": f"https://github.com/{REPO}/releases/latest",
+        }
 
     def load_driver_in_background(self):
         """Warmup the WebDriver download, only if an account is selected."""

--- a/src/api.py
+++ b/src/api.py
@@ -596,6 +596,9 @@ class AutoRewarderAPI:
         """
         cfg = self.global_settings.get_llm_config()
         cfg["effective_locale"] = self.global_settings.get_effective_locale()
+        # Lets the Settings UI label the blank model choice with the actual
+        # default id for the selected provider.
+        cfg["default_models"] = dict(llm.DEFAULT_MODELS)
         return cfg
 
     def set_llm_config(
@@ -617,6 +620,16 @@ class AutoRewarderAPI:
         except Exception as e:
             self.log(f"[WARNING] Failed to save LLM config: {e}")
             return False
+
+    def list_llm_models(self, provider, api_key):
+        """
+        Fetch the chat models `api_key` can use at `provider`, for the model
+        picker in Settings > Search terms. Never raises.
+
+        Returns:
+            dict: {ok, models: [{id, label}], error?} — see llm.list_models.
+        """
+        return llm.list_models(provider, api_key, logger=self.log)
 
     def set_detected_locale(self, locale):
         """

--- a/src/search/llm.py
+++ b/src/search/llm.py
@@ -230,7 +230,7 @@ def generate_queries(
         if logger:
             logger(f"[WARNING] LLM ({provider}) network error: {e}")
         return []
-    except (KeyError, IndexError, ValueError, TypeError) as e:
+    except (KeyError, IndexError, ValueError, TypeError, AttributeError) as e:
         if logger:
             logger(f"[WARNING] LLM ({provider}) unexpected response: {e}")
         return []
@@ -414,7 +414,7 @@ def list_models(provider, api_key, logger=None):
             "models": [],
             "error": "Network error. Check your connection.",
         }
-    except (KeyError, IndexError, ValueError, TypeError) as e:
+    except (KeyError, IndexError, ValueError, TypeError, AttributeError) as e:
         if logger:
             logger(f"[WARNING] LLM ({provider}) model list: unexpected response: {e}")
         return {

--- a/src/search/llm.py
+++ b/src/search/llm.py
@@ -30,6 +30,7 @@ DEFAULT_MODELS = {
 SUPPORTED_PROVIDERS = tuple(DEFAULT_MODELS.keys())
 
 _TIMEOUT = 30  # seconds, per request
+_LIST_TIMEOUT = 15  # seconds; the model lookup is interactive (Settings)
 _ANTHROPIC_VERSION = "2023-06-01"
 
 
@@ -52,19 +53,22 @@ def _build_prompt(count, loc):
     )
 
 
+def _http_error_reason(status):
+    """Short, user-facing reason for a non-2xx provider response."""
+    if status in (401, 403):
+        return "invalid or unauthorized API key"
+    if status == 429:
+        return "rate limit or quota exceeded"
+    if status == 402:
+        return "billing / quota exhausted"
+    return f"HTTP {status}"
+
+
 def _log_http_error(logger, provider, resp):
     """Translate a non-2xx response into a clear, actionable log line."""
     if not logger:
         return
-    status = resp.status_code
-    if status in (401, 403):
-        reason = "invalid or unauthorized API key"
-    elif status == 429:
-        reason = "rate limit or quota exceeded"
-    elif status == 402:
-        reason = "billing / quota exhausted"
-    else:
-        reason = f"HTTP {status}"
+    reason = _http_error_reason(resp.status_code)
     snippet = (resp.text or "").replace("\n", " ")[:200]
     logger(f"[WARNING] LLM ({provider}) request failed: {reason}. {snippet}")
 
@@ -235,3 +239,194 @@ def generate_queries(
     if not queries and logger:
         logger(f"[WARNING] LLM ({provider}) returned no usable queries.")
     return queries
+
+
+# ---------------------------------------------------------------------------
+# Model discovery (Settings > Search terms > "Load models")
+# ---------------------------------------------------------------------------
+
+# OpenAI's /v1/models mixes chat models with audio, image, embedding and
+# moderation endpoints. Keep the chat families and drop the obvious non-chat
+# variants; the user can still type any id through the "Custom" option.
+_OPENAI_CHAT_PREFIXES = ("gpt-", "o1", "o3", "o4", "chatgpt-")
+_OPENAI_NON_CHAT_MARKERS = (
+    "realtime",
+    "audio",
+    "tts",
+    "transcribe",
+    "whisper",
+    "image",
+    "dall-e",
+    "sora",
+    "embedding",
+    "moderation",
+    "computer-use",
+)
+_MAX_LIST_PAGES = 10
+
+
+class _ListError(Exception):
+    """A provider answered, but not with a usable model list."""
+
+
+def _check_list_response(resp):
+    if resp.status_code != 200:
+        raise _ListError(_http_error_reason(resp.status_code))
+
+
+def _is_openai_chat_model(model_id):
+    mid = model_id.lower()
+    if not mid.startswith(_OPENAI_CHAT_PREFIXES):
+        return False
+    return not any(marker in mid for marker in _OPENAI_NON_CHAT_MARKERS)
+
+
+def _list_openai(api_key):
+    resp = requests.get(
+        "https://api.openai.com/v1/models",
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=_LIST_TIMEOUT,
+    )
+    _check_list_response(resp)
+    rows = []
+    for m in resp.json().get("data", []):
+        mid = m.get("id") if isinstance(m, dict) else None
+        if mid and _is_openai_chat_model(mid):
+            rows.append((m.get("created") or 0, mid))
+    # Newest first, then alphabetical for models sharing a timestamp.
+    rows.sort(key=lambda r: (-r[0], r[1]))
+    return [{"id": mid, "label": mid} for _, mid in rows]
+
+
+def _list_anthropic(api_key):
+    rows = []
+    after_id = None
+    for _ in range(_MAX_LIST_PAGES):
+        params = {"limit": 100}
+        if after_id:
+            params["after_id"] = after_id
+        resp = requests.get(
+            "https://api.anthropic.com/v1/models",
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": _ANTHROPIC_VERSION,
+            },
+            params=params,
+            timeout=_LIST_TIMEOUT,
+        )
+        _check_list_response(resp)
+        body = resp.json()
+        for m in body.get("data", []):
+            if not isinstance(m, dict) or not m.get("id"):
+                continue
+            rows.append(
+                (
+                    m.get("created_at") or "",
+                    m["id"],
+                    m.get("display_name") or m["id"],
+                )
+            )
+        after_id = body.get("last_id")
+        if not body.get("has_more") or not after_id:
+            break
+    # created_at is ISO-8601, so a plain string sort is chronological.
+    rows.sort(key=lambda r: (r[0], r[1]), reverse=True)
+    return [{"id": mid, "label": label} for _, mid, label in rows]
+
+
+def _list_gemini(api_key):
+    rows = []
+    page_token = None
+    for _ in range(_MAX_LIST_PAGES):
+        params = {"key": api_key, "pageSize": 100}
+        if page_token:
+            params["pageToken"] = page_token
+        resp = requests.get(
+            "https://generativelanguage.googleapis.com/v1beta/models",
+            params=params,
+            timeout=_LIST_TIMEOUT,
+        )
+        _check_list_response(resp)
+        body = resp.json()
+        for m in body.get("models", []):
+            if not isinstance(m, dict):
+                continue
+            # Only models that answer generateContent can produce queries;
+            # this drops embeddings, AQA, TTS and image-only variants.
+            if "generateContent" not in (m.get("supportedGenerationMethods") or []):
+                continue
+            name = m.get("name") or ""
+            mid = name.split("/", 1)[1] if name.startswith("models/") else name
+            if mid:
+                rows.append((mid, m.get("displayName") or mid))
+        page_token = body.get("nextPageToken")
+        if not page_token:
+            break
+    # Ids embed the version ("gemini-3.1-..." > "gemini-2.5-..."), so a
+    # reverse sort puts the newest families first.
+    rows.sort(reverse=True)
+    return [{"id": mid, "label": label} for mid, label in rows]
+
+
+_LIST_DISPATCH = {
+    "openai": _list_openai,
+    "anthropic": _list_anthropic,
+    "gemini": _list_gemini,
+}
+
+
+def list_models(provider, api_key, logger=None):
+    """List the chat models `api_key` can use at `provider`.
+
+    Meant for the Settings UI, so the outcome is returned rather than logged
+    and the function **never raises**.
+
+    Returns:
+        dict: ``{"ok": True, "models": [{"id", "label"}, ...]}`` on success,
+        ``{"ok": False, "models": [], "error": "<reason>"}`` otherwise.
+    """
+    provider = (provider or "").strip().lower()
+    api_key = (api_key or "").strip()
+    lister = _LIST_DISPATCH.get(provider)
+    if lister is None:
+        return {
+            "ok": False,
+            "models": [],
+            "error": f"Unsupported provider '{provider}'.",
+        }
+    if not api_key:
+        return {"ok": False, "models": [], "error": "Enter an API key first."}
+
+    try:
+        models = lister(api_key)
+    except _ListError as e:
+        reason = str(e)
+        return {
+            "ok": False,
+            "models": [],
+            "error": reason[:1].upper() + reason[1:] + ".",
+        }
+    except requests.RequestException as e:
+        if logger:
+            logger(f"[WARNING] LLM ({provider}) model list: network error: {e}")
+        return {
+            "ok": False,
+            "models": [],
+            "error": "Network error. Check your connection.",
+        }
+    except (KeyError, IndexError, ValueError, TypeError) as e:
+        if logger:
+            logger(f"[WARNING] LLM ({provider}) model list: unexpected response: {e}")
+        return {
+            "ok": False,
+            "models": [],
+            "error": "Unexpected response from the provider.",
+        }
+
+    if not models:
+        return {
+            "ok": False,
+            "models": [],
+            "error": "No chat model returned for this key.",
+        }
+    return {"ok": True, "models": models}


### PR DESCRIPTION
The Settings modal had turned into one long scroll — General, Daily tasks, Search terms, then a schedule accordion per account — with account management living in a separate modal. This reorganises it; the settings storage and the existing setters are untouched.

## What changed

- **Side navigation.** Application sections (General, Daily tasks, Search terms, About) on the left, then one entry per account. One section visible at a time.
- **One page per account.** Rename, re-run setup, delete, the Rewards dashboard choice and the schedule now sit together. This replaces both the "Your accounts" modal and the schedule accordion, so the header keeps a single gear button (the account dropdown still has an "Account settings…" shortcut).
- **Save that says what it saves.** Edited sections get a marker in the nav, the footer counts pending changes, and closing with unsaved edits asks first. The modal only closes through Save or Cancel.
- **Search terms.** A link to the API-key page of the selected provider, and a model picker that fetches the models your key can use (OpenAI, Anthropic, Gemini) instead of a free-text field. "Default" and "Custom…" are still available.
- **About.** Version, on-demand update check, and a button to open the data folder.

Backend side: three small API methods for About and one for the model list. User guide updated accordingly.

## Screenshot

<img width="619" height="730" alt="image" src="https://github.com/user-attachments/assets/a8e03322-5f3e-47af-a65d-e5c4e9ab78d7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned Settings with side navigation and dedicated pages for each account.
  - Manage account setup, Rewards, schedules, and troubleshooting directly from account pages.
  - Added provider-based LLM model selection, model refresh, custom models, and API-key visibility controls.
  - Added an About page with app details, update checks, and data-folder access.
  - Added unsaved-change indicators and prompts before discarding edits.
- **Bug Fixes**
  - Prevented saving while Settings is still loading and handled failed loads safely.
- **Documentation**
  - Updated the user guide for the redesigned Settings experience and LLM configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->