### PR TITLE
HOTFIX: visual search no longer credits the Rewards streak

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -2572,62 +2572,90 @@ class AutoRewarderAPI:
         self._visual_search_attempted = True
 
         used_images = self.daily_set.get_used_visual_search_images()
+        mission_url = getattr(self.daily_set, "visual_search_url", None)
 
-        image_id, updated_images = self.search_engine.get_next_image_id(used_images)
+        # Surface to search from: None lets the engine use its own order; the
+        # second pass forces the other one when Rewards ignored the first.
+        search_url = None
 
-        image_path = self.search_engine.prepare_unique_image(image_id)
+        for attempt in (1, 2):
+            image_id, updated_images = self.search_engine.get_next_image_id(used_images)
 
-        if image_path is None:
-            return False
+            image_path = self.search_engine.prepare_unique_image(image_id)
 
-        try:
-            success = self.search_engine.perform_visual_search(
-                self._driver,
-                image_path,
-                stop_event=self._stop_event,
-                entry_url=getattr(self.daily_set, "visual_search_url", None),
-            )
-
-            # Rewards is the authority, in both directions: a results page is
-            # not proof of credit, and Bing rendering the results somewhere we
-            # didn't recognise is not proof of failure. So ask the mission.
-            stopped = self._stop_event is not None and self._stop_event.is_set()
-            credited = None if stopped else self._check_visual_search_credited()
-
-            # The image reached Bing in either of these cases, so don't offer it
-            # again on the next run.
-            if success or credited is True:
-                self.daily_set.save_used_visual_search_images(updated_images)
-
-            if not success:
-                if credited is not True:
-                    return False
-                self.log(
-                    "Bing's results page never loaded, but Rewards counted the "
-                    "search anyway."
-                )
-            elif credited is False:
-                self.log(
-                    "[WARNING] Rewards did not count the visual search. "
-                    "Not marked as done for today."
-                )
+            if image_path is None:
                 return False
 
-            self.daily_set.mark_visual_search_as_completed()
-            self.log("Visual search marked as done for today.")
+            try:
+                success = self.search_engine.perform_visual_search(
+                    self._driver,
+                    image_path,
+                    stop_event=self._stop_event,
+                    entry_url=mission_url,
+                    search_url=search_url,
+                )
 
-            return True
+                # Rewards is the authority, in both directions: a results page
+                # is not proof of credit, and Bing rendering the results
+                # somewhere we didn't recognise is not proof of failure. So ask
+                # the mission.
+                stopped = self._stop_event is not None and self._stop_event.is_set()
+                credited = None if stopped else self._check_visual_search_credited()
 
-        except Exception as e:
-            self.log(f"[WARNING] Visual search failed: {e}")
-            return False
+                # The image reached Bing in either of these cases, so don't
+                # offer it again on the next run.
+                if success or credited is True:
+                    self.daily_set.save_used_visual_search_images(updated_images)
+                    used_images = updated_images
 
-        finally:
-            if os.path.exists(image_path):
-                try:
-                    os.remove(image_path)
-                except Exception as e:
-                    self.log(f"[WARNING] Failed to remove temporary image file: {e}")
+                if not success:
+                    if credited is not True:
+                        return False
+                    self.log(
+                        "Bing's results page never loaded, but Rewards counted "
+                        "the search anyway."
+                    )
+                elif credited is False:
+                    # Which surface Rewards credits is Microsoft's call and has
+                    # changed before, so one refusal doesn't write the day off:
+                    # search again from the other surface, once, with a fresh
+                    # image.
+                    other = self.search_engine.other_surface_url()
+
+                    if attempt == 1 and other and not stopped:
+                        self.log(
+                            f"Rewards ignored a search from "
+                            f"{self.search_engine.last_search_url}. "
+                            f"Trying again from {other}."
+                        )
+                        search_url = other
+                        continue
+
+                    self.log(
+                        "[WARNING] Rewards did not count the visual search. "
+                        "Not marked as done for today."
+                    )
+                    return False
+
+                self.daily_set.mark_visual_search_as_completed()
+                self.log("Visual search marked as done for today.")
+
+                return True
+
+            except Exception as e:
+                self.log(f"[WARNING] Visual search failed: {e}")
+                return False
+
+            finally:
+                if os.path.exists(image_path):
+                    try:
+                        os.remove(image_path)
+                    except Exception as e:
+                        self.log(
+                            f"[WARNING] Failed to remove temporary image file: {e}"
+                        )
+
+        return False
 
     def _check_visual_search_credited(self):
         """

--- a/src/dailytasks/new_dashboard.py
+++ b/src/dailytasks/new_dashboard.py
@@ -275,14 +275,21 @@ try {
   for (var i = 0; i < imgs.length; i++) {
     var card = imgs[i].parentElement;
     for (var up = 0; card && up < 8; up++) {
+      var text = (card.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 90);
       var bar = card.querySelector('[role="progressbar"][aria-valuemax]');
       if (bar) {
         var now = parseInt(bar.getAttribute('aria-valuenow'), 10);
         var max = parseInt(bar.getAttribute('aria-valuemax'), 10);
-        if (!isNaN(now) && !isNaN(max) && max > 0) return {done: now, total: max};
+        if (!isNaN(now) && !isNaN(max) && max > 0) {
+          return {done: now, total: max, source: 'progressbar',
+                  card: text || bar.getAttribute('aria-label') || ''};
+        }
       }
       var m = (card.textContent || '').replace(/\s+/g, ' ').match(/(\d+)\s*\/\s*(\d+)/);
-      if (m) return {done: parseInt(m[1], 10), total: parseInt(m[2], 10)};
+      if (m) {
+        return {done: parseInt(m[1], 10), total: parseInt(m[2], 10),
+                source: 'counter', card: text};
+      }
       card = card.parentElement;
     }
   }
@@ -803,12 +810,27 @@ class NewDashboardDailySet:
             return None
 
         if not isinstance(data, dict):
+            self._log(
+                "[INFO] No visual search streak card on the dashboard "
+                "(mission not offered, or its markup changed)."
+            )
             return None
 
         try:
-            return int(data["done"]), int(data["total"])
+            done, total = int(data["done"]), int(data["total"])
         except (KeyError, TypeError, ValueError):
             return None
+
+        # A zero is the reading that decides whether the day counts, so show
+        # what it was read from: a card that isn't the mission's, or a stale
+        # page, would otherwise look exactly like "Rewards didn't count it".
+        if done == 0:
+            self._log(
+                f"[INFO] Streak read as {done}/{total} from the "
+                f"{data.get('source', '?')} of: {data.get('card', '?')!r}"
+            )
+
+        return done, total
 
     def _find_claim_tile(self, driver):
         """

--- a/src/search/engine.py
+++ b/src/search/engine.py
@@ -1,6 +1,8 @@
 """Search automation helpers for Bing queries."""
 
+import base64
 import json
+import os
 import random
 import time
 from urllib.parse import urlparse
@@ -20,13 +22,21 @@ REWARDS_VISUAL_SEARCH_URL = (
     "https://www.bing.com/?features=vsstreak,vstooltip&form=ML2XES"
 )
 
-# Entry points for the "search by image" widget, tried in order. The homepage
-# only injects the camera button through a lazy fragment, and some flights ship
-# no fragment at all, while the Images vertical always renders it server-side.
+# The Images vertical, and the surface the search actually runs on: Bing stamps
+# a search started there with FORM=SBIIRP, and that is the only code the Rewards
+# streak has been observed to credit. The homepage camera reports FORM=SBIHMP
+# and went uncredited even though the search itself succeeded. Bing replaces the
+# entry page's own form code either way, so the mission's promo code never
+# reaches the search — only the surface does.
+VISUAL_SEARCH_IMAGES_URL = "https://www.bing.com/images"
+
+# Entry points for the "search by image" widget, tried in order. Images first
+# for the reason above; it also renders the camera button server-side, while the
+# homepage only injects it through a lazy fragment that some flights don't ship.
 VISUAL_SEARCH_URLS = (
+    VISUAL_SEARCH_IMAGES_URL,
     REWARDS_VISUAL_SEARCH_URL,
     "https://www.bing.com",
-    "https://www.bing.com/images",
 )
 
 # Selectors for the camera button, from the most to the least specific.
@@ -35,6 +45,26 @@ VISUAL_SEARCH_BUTTON_LOCATORS = (
     (By.CSS_SELECTOR, "#sbiarea [role='button']"),
     (By.ID, "sbi_b"),
 )
+
+# Hand the image to Bing the way a person does: dropped on the flyout, which
+# advertises a drop target (data-drpanywhr / drop-eff-id) and handles it with
+# its own code path. Writing the file straight into the hidden input skips that
+# path entirely — the search still runs, but whatever the flyout reports to
+# Rewards on a real drop never fires.
+_DROP_IMAGE_JS = r"""
+var b64 = arguments[0], name = arguments[1], target = arguments[2] || document.body;
+var bin = atob(b64), bytes = new Uint8Array(bin.length);
+for (var i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+var file = new File([bytes], name, {type: 'image/jpeg'});
+var dt = new DataTransfer();
+dt.items.add(file);
+['dragenter', 'dragover', 'drop'].forEach(function (type) {
+  target.dispatchEvent(
+    new DragEvent(type, {bubbles: true, cancelable: true, dataTransfer: dt})
+  );
+});
+return dt.files.length;
+"""
 
 # The upload flyout itself. #sb_fileinput sits in the DOM whether or not the
 # flyout is open, and a file sent to it while it is closed goes nowhere, so this
@@ -71,6 +101,9 @@ class SearchEngine:
 
         self._logger = logger
         self._history = history
+        # Surface the last successful search ran on, so the caller can ask for
+        # the other one when Rewards doesn't credit that one.
+        self.last_search_url = None
 
     def _log(self, message):
         """
@@ -421,7 +454,7 @@ class SearchEngine:
             return "stopped"
 
         if button is None:
-            self._log(f"[WARNING] No visual search button on {url}.")
+            self._log(f"[INFO] No visual search button on {url}.")
             return "no widget"
 
         human.click_element(button)
@@ -431,7 +464,7 @@ class SearchEngine:
         if not self._open_upload_panel(
             driver, human, button, poll_interval, stop_event
         ):
-            self._log(f"[WARNING] Upload flyout stayed closed on {url}.")
+            self._log(f"[INFO] Upload flyout stayed closed on {url}.")
             return "stopped" if self._stopped(stop_event) else "no widget"
 
         upload_input = self._find_visual_search_element(
@@ -442,15 +475,26 @@ class SearchEngine:
             stop_event=stop_event,
         )
 
-        if upload_input is None:
-            self._log(f"[WARNING] No image upload field on {url}.")
-            return "stopped" if self._stopped(stop_event) else "no widget"
+        panel = self._find_visual_search_element(
+            driver,
+            ((By.CSS_SELECTOR, VISUAL_SEARCH_PANEL_SELECTOR),),
+            timeout=0,
+            poll_interval=poll_interval,
+        )
 
         time.sleep(random.uniform(1, 4))
 
-        # Send the file path to the hidden type="file" input element
         known_tabs = self._tab_snapshot(driver)
-        upload_input.send_keys(image_path)
+
+        # Drop it on the flyout first; fall back to writing the path into the
+        # hidden input, which works but skips the flyout's own drop handling.
+        if not self._drop_image(driver, image_path, panel):
+            if upload_input is None:
+                self._log(f"[INFO] No way to hand over the image on {url}.")
+                return "stopped" if self._stopped(stop_event) else "no widget"
+
+            self._log("[INFO] Drop not accepted; using the file input instead.")
+            upload_input.send_keys(image_path)
 
         if self._wait_for_visual_search_results(
             driver,
@@ -460,13 +504,14 @@ class SearchEngine:
             stop_event=stop_event,
             known_tabs=known_tabs,
         ):
+            self.last_search_url = url
             return "done"
 
         if self._stopped(stop_event):
             return "stopped"
 
         self._log(
-            f"[WARNING] Uploaded from {url} but no results came back "
+            f"[INFO] Uploaded from {url} but no results came back "
             f"({self._page_state(driver)})."
         )
         return "no results"
@@ -474,6 +519,37 @@ class SearchEngine:
     def _stopped(self, stop_event):
         """Whether Stop was requested."""
         return stop_event is not None and stop_event.is_set()
+
+    def _drop_image(self, driver, image_path, target=None):
+        """
+        Drop the image on Bing's upload zone, as a drag-and-drop would.
+
+        Args:
+            driver (WebDriver): An instance of Selenium WebDriver to control the browser.
+            image_path (str): Path of the image to hand over.
+            target (WebElement, optional): Element to drop on. Defaults to the
+                page body, which the flyout listens on (data-drpanywhr).
+
+        Returns:
+            bool: True when the drop was dispatched with the file attached.
+        """
+        try:
+            with open(image_path, "rb") as image:
+                payload = base64.b64encode(image.read()).decode("ascii")
+        except OSError as e:
+            self._log(f"[INFO] Could not read the image to drop it: {e}")
+            return False
+
+        try:
+            files = driver.execute_script(
+                _DROP_IMAGE_JS, payload, os.path.basename(image_path), target
+            )
+        except WebDriverException as e:
+            short_error = str(e).split("\n")[0][:40]
+            self._log(f"[INFO] Drop upload failed ({short_error}).")
+            return False
+
+        return bool(files)
 
     def _open_upload_panel(self, driver, human, button, poll_interval, stop_event=None):
         """
@@ -730,8 +806,28 @@ class SearchEngine:
 
         return False
 
+    def other_surface_url(self):
+        """
+        The surface to try when Rewards ignored the search we just made.
+
+        Which surface credits the streak is Microsoft's call and has changed
+        before, so the caller retries on the other one rather than trusting
+        our own ordering.
+
+        Returns:
+            str: The other surface's URL, or None if the last search's surface
+                isn't known.
+        """
+        if not self.last_search_url:
+            return None
+
+        if self.last_search_url == VISUAL_SEARCH_IMAGES_URL:
+            return REWARDS_VISUAL_SEARCH_URL
+
+        return VISUAL_SEARCH_IMAGES_URL
+
     def perform_visual_search(
-        self, driver, image_path, stop_event=None, entry_url=None
+        self, driver, image_path, stop_event=None, entry_url=None, search_url=None
     ):
         """
         Perform a visual search on Bing using an image file.
@@ -740,9 +836,12 @@ class SearchEngine:
             driver (WebDriver): An instance of Selenium WebDriver to control the browser.
             image_path (str): The path to the image file to use for the visual search.
             stop_event (threading.Event, optional): If provided and set, the search will be cancelled.
-            entry_url (str, optional): Page to start from, tried before the
-                defaults. Used for the Rewards mission link read off the
-                dashboard, which is what makes the search credit the streak.
+            entry_url (str, optional): The Rewards mission link read off the
+                dashboard, opened once before searching. Falls back to the
+                known mission URL.
+            search_url (str, optional): Surface to run the search on, tried
+                before the defaults. Used to retry on the other surface when
+                Rewards didn't credit the first one.
 
         Returns:
             bool: True if the visual search was successful, False otherwise.
@@ -762,11 +861,30 @@ class SearchEngine:
         human = HumanBehavior(driver, show_cursor=True, mobile=False)
         step = "opening Bing"
 
+        mission_url = entry_url or REWARDS_VISUAL_SEARCH_URL
+
         entry_urls = list(VISUAL_SEARCH_URLS)
-        if entry_url and entry_url not in entry_urls:
-            entry_urls.insert(0, entry_url)
+        if mission_url not in entry_urls:
+            entry_urls.insert(1, mission_url)
+        if search_url:
+            if search_url in entry_urls:
+                entry_urls.remove(search_url)
+            entry_urls.insert(0, search_url)
 
         try:
+            # Open the mission's own link once before searching, the way the
+            # dashboard's "Search now" button does. Every search that has
+            # credited the streak so far happened after this visit, so it stays
+            # — it costs one page load and the search itself runs on Images.
+            try:
+                driver.get(mission_url)
+                time.sleep(random.uniform(1, 3))
+            except WebDriverException as e:
+                short_error = str(e).split("\n")[0][:28]
+                self._log(
+                    f"[INFO] Could not open the mission link ({short_error}). Continuing."
+                )
+
             outcome = "no widget"
 
             for url in entry_urls:
@@ -778,13 +896,23 @@ class SearchEngine:
                     break
 
                 if outcome == "no results":
-                    # The upload went nowhere on this surface. bing.com is the
-                    # same uploader as the mission link, so the only retry worth
-                    # the time is the Images vertical.
-                    last = entry_urls[-1]
-                    if url != last:
+                    # The upload went nowhere on this surface. The homepage and
+                    # the mission link share one uploader, so the only retry
+                    # worth the time is the other surface: Images.
+                    alternate = (
+                        mission_url
+                        if url == VISUAL_SEARCH_IMAGES_URL
+                        else VISUAL_SEARCH_IMAGES_URL
+                    )
+                    if url != alternate:
+                        self._log(f"Retrying the visual search from {alternate}.")
                         outcome = self._attempt_visual_search(
-                            driver, human, last, image_path, poll_interval, stop_event
+                            driver,
+                            human,
+                            alternate,
+                            image_path,
+                            poll_interval,
+                            stop_event,
                         )
                     break
 
@@ -869,6 +997,7 @@ class SearchEngine:
             str: The path to the prepared image, or None if preparation failed.
         """
         import os
+        import secrets
         import tempfile
 
         from PIL import Image
@@ -903,9 +1032,14 @@ class SearchEngine:
 
                 random_quality = random.randint(65, 95)
 
-                file_descriptor, temp_path = tempfile.mkstemp(
-                    prefix="AutoRewarder_visual_search_",
-                    suffix=".jpg",
+                # A plain random name: the temp file's name travels with the
+                # upload, and there is no reason for this app's name to end up
+                # in it. O_EXCL keeps the creation race-free, as mkstemp did.
+                temp_path = os.path.join(
+                    tempfile.gettempdir(), f"{secrets.token_hex(16)}.jpg"
+                )
+                file_descriptor = os.open(
+                    temp_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600
                 )
 
                 with os.fdopen(file_descriptor, "wb") as temp_file:

--- a/src/search/engine.py
+++ b/src/search/engine.py
@@ -66,6 +66,21 @@ dt.items.add(file);
 return dt.files.length;
 """
 
+# State of the upload zone, sampled before and after a drop. An accepted drop
+# flips the flyout into its loading state within half a second (and navigates
+# about a second later), so any of these moving is proof the page took the file
+# — including Bing answering with an error, which the file input wouldn't fix.
+_UPLOAD_ZONE_STATE_JS = r"""
+var pane = document.querySelector(arguments[0]);
+var loading = document.querySelector('#loadingimg, .loadingdiv, .dpload');
+return {
+  url: location.href,
+  pane: pane ? (pane.innerText || '').replace(/\s+/g, ' ').trim() : null,
+  shown: pane ? !!pane.getClientRects().length : null,
+  loading: loading ? !!loading.getClientRects().length : false
+};
+"""
+
 # The upload flyout itself. #sb_fileinput sits in the DOM whether or not the
 # flyout is open, and a file sent to it while it is closed goes nowhere, so this
 # is what tells us the camera click actually landed.
@@ -540,6 +555,8 @@ class SearchEngine:
             self._log(f"[INFO] Could not read the image to drop it: {e}")
             return False
 
+        before = self._upload_zone_state(driver)
+
         try:
             files = driver.execute_script(
                 _DROP_IMAGE_JS, payload, os.path.basename(image_path), target
@@ -549,7 +566,54 @@ class SearchEngine:
             self._log(f"[INFO] Drop upload failed ({short_error}).")
             return False
 
-        return bool(files)
+        if not files:
+            return False
+
+        # A DataTransfer carrying the file proves nothing about the page: a
+        # build that ignores synthetic drag events leaves it just as full. So
+        # wait for the zone to actually react, and let the caller fall back to
+        # the file input when it doesn't.
+        return self._drop_accepted(driver, before, timeout=5, poll_interval=0.25)
+
+    def _upload_zone_state(self, driver):
+        """Sample the upload zone's URL, flyout text and loading state."""
+        try:
+            state = driver.execute_script(
+                _UPLOAD_ZONE_STATE_JS, VISUAL_SEARCH_PANEL_SELECTOR
+            )
+        except WebDriverException:
+            return {}
+
+        return state if isinstance(state, dict) else {}
+
+    def _drop_accepted(self, driver, before, timeout, poll_interval, stop_event=None):
+        """
+        Whether the page reacted to the drop within `timeout` seconds.
+
+        Returns:
+            bool: True once the flyout starts loading, changes what it says,
+                closes, or the page navigates. False if nothing moved.
+        """
+        deadline = time.monotonic() + timeout
+
+        while True:
+            if stop_event is not None and stop_event.is_set():
+                return False
+
+            after = self._upload_zone_state(driver)
+
+            if after and (
+                after.get("loading")
+                or after.get("url") != before.get("url")
+                or after.get("pane") != before.get("pane")
+                or after.get("shown") != before.get("shown")
+            ):
+                return True
+
+            if time.monotonic() >= deadline:
+                return False
+
+            time.sleep(poll_interval)
 
     def _open_upload_panel(self, driver, human, button, poll_interval, stop_event=None):
         """


### PR DESCRIPTION
Since 4.3 the visual search stopped earning the daily point, and quietly: Bing
accepted the image, returned a results page, and the streak mission stayed at
`Activity: 0/1`.

Ruled out on my account: the mission (its card and link are unchanged), the
images (all first-use), our reading of the progress, and any quota or outage —
a visual search done by hand credits on a day an automated one doesn't.

The difference left: we wrote the file into the hidden `#sb_fileinput`, while a
person drops it on the flyout, which has its own drop target (`data-drpanywhr`)
and its own handler. The image is dropped there now, input kept as fallback.
The search runs on the Images vertical after opening the mission link once, and
one that succeeds without being credited is retried from the other surface —
with the day left unmarked when nothing counted, so the next run retries.

The drop is a hypothesis: I can verify it starts the search, not that it
credits. Hence the check and the retry — a failure now says so instead of the
app claiming success.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Visual search now starts on the Images experience by default.
  - Image uploads use a more reliable drag-and-drop flow, with fallback support and confirmation that uploads are accepted.
  - Searches can retry on an alternate search experience when results or reward credit are unavailable.
  - Search progress tracking provides clearer status information when mission cards or progress values are unavailable.

- **Bug Fixes**
  - Successful progress is recorded accurately, while unsuccessful retries do not incorrectly mark the day complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->